### PR TITLE
古い署名を削除 ＆ Streamで同期しない

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 build:
 	go build -o bin/oasvlfy .
 
+.PHONY: proto
+proto:
+	protoc --go_out=./proto/p2p/v1  \
+	./proto/p2p/v1/*.proto
+
 fmt:
 	go fmt ./...
+
+fmtproto:
+	clang-format -i ./proto/p2p/**/*.proto
 
 test:
 	go test -v ./...

--- a/cmd/config_loader.go
+++ b/cmd/config_loader.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/oasysgames/oasys-optimism-verifier/config"
@@ -139,7 +139,7 @@ func mustNewConfigLoader(cmd *cobra.Command) *configLoader {
 	return opts
 }
 
-func (opts *configLoader) load() (*config.Config, error) {
+func (opts *configLoader) load(enableStrictValidation bool) (*config.Config, error) {
 	// load config from the file
 	if !opts.fromCli {
 		path, err := opts.cmd.Flags().GetString(fileConfigFlag)
@@ -147,12 +147,12 @@ func (opts *configLoader) load() (*config.Config, error) {
 			return nil, err
 		}
 
-		input, err := ioutil.ReadFile(path)
+		input, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
 
-		conf, err := config.NewConfig(input)
+		conf, err := config.NewConfig(input, true)
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +188,7 @@ func (opts *configLoader) load() (*config.Config, error) {
 		}
 	}
 
-	if err := config.Validate(opts.cfg); err != nil {
+	if err := config.Validate(opts.cfg, enableStrictValidation); err != nil {
 		return nil, err
 	}
 

--- a/cmd/config_loader_test.go
+++ b/cmd/config_loader_test.go
@@ -338,6 +338,7 @@ func (s *ConfigLoaderTestSuite) configWithMinCliArgs() *config.Config {
 			StateCollectTimeout: defaults["verifier.state_collect_timeout"].(time.Duration),
 			OptimizeInterval:    defaults["verifier.db_optimize_interval"].(time.Duration),
 			Confirmations:       defaults["verifier.confirmations"].(int),
+			StartBlockOffset:    defaults["verifier.start_block_offset"].(uint64),
 		},
 		Submitter: config.Submitter{
 			Enable:              false,

--- a/cmd/config_loader_test.go
+++ b/cmd/config_loader_test.go
@@ -123,7 +123,7 @@ func (s *ConfigLoaderTestSuite) TestLoadConfigFromYAML() {
 	})
 	rootCmd.Execute()
 
-	got, _ := globalConfigLoader.load()
+	got, _ := globalConfigLoader.load(false)
 	s.Equal(want, got)
 }
 
@@ -227,7 +227,8 @@ func (s *ConfigLoaderTestSuite) executeWithCliArgs(appendArgs []string) *config.
 	}, appendArgs...))
 	cmd.Execute()
 
-	conf, _ := opts.load()
+	conf, err := opts.load(false)
+	s.Require().NoError(err)
 	return conf
 }
 

--- a/cmd/config_loader_test.go
+++ b/cmd/config_loader_test.go
@@ -57,11 +57,11 @@ func (s *ConfigLoaderTestSuite) TestLoadConfigFromYAML() {
 			address: '0xD244F03CA3e99C6093f6cBEFBD2f4508244C59D4'
 			password: %s
 			plain: '0xebf3a7f5f805e02c0bbbd599acd5c881f40db22caa95127d4bf48e2dde5fd7bb'
-	
+
 	hub_layer:
 		chain_id: 1
 		rpc: https://rpc.hub.example.com/
-	
+
 	verse_layer:
 		discovery:
 			endpoint: https://discovery.example.com/
@@ -71,7 +71,7 @@ func (s *ConfigLoaderTestSuite) TestLoadConfigFromYAML() {
 			  l1_contracts:
 			    StateCommitmentChain: '0x01E901F3c65fA7CBd4505F5eF3A88e4ce432e4B5'
 			    L2OutputOracle: '0x2489317FA6e003550111D5D196302Ba0879354e2'
-	
+
 	p2p:
 		listens:
 			- listen0
@@ -92,7 +92,7 @@ func (s *ConfigLoaderTestSuite) TestLoadConfigFromYAML() {
 	verifier:
 		enable: true
 		wallet: verifier
-	
+
 	submitter:
 		enable: true
 		confirmations: 10
@@ -336,6 +336,7 @@ func (s *ConfigLoaderTestSuite) configWithMinCliArgs() *config.Config {
 			StateCollectLimit:   defaults["verifier.state_collect_limit"].(int),
 			StateCollectTimeout: defaults["verifier.state_collect_timeout"].(time.Duration),
 			OptimizeInterval:    defaults["verifier.db_optimize_interval"].(time.Duration),
+			Confirmations:       defaults["verifier.confirmations"].(int),
 		},
 		Submitter: config.Submitter{
 			Enable:              false,

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -16,7 +16,7 @@ var pingCmd = &cobra.Command{
 	Short: "Send ping via P2P to specified peer",
 	Long:  "Send ping via P2P to specified peer",
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := globalConfigLoader.load()
+		conf, err := globalConfigLoader.load(true)
 		if err != nil {
 			util.Exit(1, "Failed to load configuration: %s\n", err)
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -479,9 +479,7 @@ func (s *server) startVerseDiscovery(ctx context.Context) {
 			log.Info("Verse discovery has stopped, decrement wait group")
 		}()
 
-		// The first tick is immediate
-		isFirstTick := true
-		discTick := time.NewTicker(0)
+		discTick := time.NewTicker(s.conf.VerseLayer.Discovery.RefreshInterval)
 		defer discTick.Stop()
 
 		// Subscribed verses to verifier and submitter
@@ -497,11 +495,6 @@ func (s *server) startVerseDiscovery(ctx context.Context) {
 				return
 			case verses := <-sub.Next():
 				s.verseDiscoveryHandler(ctx, verses)
-				if isFirstTick {
-					// From second tick, the interval is used
-					discTick.Reset(s.conf.VerseLayer.Discovery.RefreshInterval)
-					isFirstTick = false
-				}
 			case <-discTick.C:
 				if err := disc.Work(ctx); err != nil {
 					log.Error("Failed to work verse discovery", "err", err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -220,7 +220,10 @@ func (s *server) mustStartMetrics(ctx context.Context) {
 	go func() {
 		// NOTE: Don't add wait group, as no need to guarantee the completion
 		if err := metrics.ListenAndServe(ctx, s.msvr); err != nil {
-			log.Crit("Failed to start metrics server", "err", err)
+			// `ErrServerClosed` is thrown when `Shutdown` is intentionally called
+			if !errors.Is(err, http.ErrServerClosed) {
+				log.Crit("Failed to start metrics server", "err", err)
+			}
 		}
 		log.Info("Metrics server have exited listening", "addr", s.conf.Metrics.Listen)
 	}()
@@ -237,7 +240,10 @@ func (s *server) mustStartPprof(ctx context.Context) {
 	go func() {
 		// NOTE: Don't add wait group, as no need to guarantee the completion
 		if err := ps.ListenAndServe(ctx, s.psvr); err != nil {
-			log.Crit("Failed to start pprof server", "err", err)
+			// `ErrServerClosed` is thrown when `Shutdown` is intentionally called
+			if !errors.Is(err, http.ErrServerClosed) {
+				log.Crit("Failed to start pprof server", "err", err)
+			}
 		}
 		log.Info("pprof server have exited listening", "addr", s.conf.Debug.Pprof.Listen)
 	}()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -555,8 +555,7 @@ func (s *server) verseDiscoveryHandler(ctx context.Context, discovers []*config.
 				log.Error("Failed to construct verse-layer client", "err", err)
 			} else {
 				log.Info("Add verse to Verifier", "chain-id", x.cfg.ChainID, "contract", x.verse.RollupContract())
-				// s.verifier.AddTask(x.verse.WithVerifiable(l2Client))
-				s.verifier.AddVerse(ctx, x.verse.WithVerifiable(l2Client), x.cfg.ChainID)
+				s.verifier.AddTask(ctx, x.verse.WithVerifiable(l2Client), x.cfg.ChainID)
 			}
 		}
 
@@ -575,8 +574,7 @@ func (s *server) verseDiscoveryHandler(ctx context.Context, discovers []*config.
 
 				log.Info("Add verse to Submitter", "chain-id", x.cfg.ChainID, "contract", x.verse.RollupContract())
 				l1Signer := ethutil.NewSignableClient(new(big.Int).SetUint64(s.conf.HubLayer.ChainID), s.hub, signer)
-				// s.submitter.AddTask(x.verse.WithTransactable(l1Signer, x.verify))
-				s.submitter.AddVerse(ctx, x.verse.WithTransactable(l1Signer, x.verify), x.cfg.ChainID)
+				s.submitter.AddTask(ctx, x.verse.WithTransactable(l1Signer, x.verify), x.cfg.ChainID)
 			}
 		}
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -472,6 +472,12 @@ func (s *server) startVerseDiscovery(ctx context.Context) {
 		log.Crit("Failed to construct verse discovery", "err", err)
 	}
 
+	// synchronously try the first discovery
+	if err := disc.Work(ctx); err != nil {
+		// exit if the first discovery faild, because the following discovery highly likely fail
+		log.Crit("Failed to work verse discovery", "err", err)
+	}
+
 	s.wg.Add(1)
 	go func() {
 		defer func() {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -462,11 +462,15 @@ func (s *server) startVerseDiscovery(ctx context.Context) {
 	}
 
 	// dinamically discovered verses
-	disc := config.NewVerseDiscovery(
+	disc, err := config.NewVerseDiscovery(
+		ctx,
 		http.DefaultClient,
 		s.conf.VerseLayer.Discovery.Endpoint,
 		s.conf.VerseLayer.Discovery.RefreshInterval,
 	)
+	if err != nil {
+		log.Crit("Failed to construct verse discovery", "err", err)
+	}
 
 	s.wg.Add(1)
 	go func() {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -302,9 +302,8 @@ func (s *server) mustStartP2P(ctx context.Context, ipc *ipc.IPCServer) {
 	go func() {
 		defer s.wg.Done()
 
-		subscribeSigs := s.conf.Submitter.Enable
-		s.p2p.Start(ctx, subscribeSigs)
-		log.Info("P2P node has stopped, decrement wait group")
+		enableSubscriber := s.conf.Submitter.Enable
+		s.p2p.Start(ctx, enableSubscriber)
 	}()
 }
 
@@ -364,7 +363,7 @@ func (s *server) mustSetupVerifier() {
 	}
 
 	l1Signer := ethutil.NewSignableClient(new(big.Int).SetUint64(s.conf.HubLayer.ChainID), s.hub, signer)
-	s.verifier = verifier.NewVerifier(&s.conf.Verifier, s.db, l1Signer)
+	s.verifier = verifier.NewVerifier(&s.conf.Verifier, s.db, s.p2p, l1Signer)
 }
 
 func (s *server) startVerifier(ctx context.Context) {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -174,7 +174,7 @@ func mustNewServer(ctx context.Context) *server {
 		signers: map[string]ethutil.Signer{},
 	}
 
-	if s.conf, err = globalConfigLoader.load(); err != nil {
+	if s.conf, err = globalConfigLoader.load(true); err != nil {
 		log.Crit("Failed to load configuration", "err", err)
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,7 +11,7 @@ var statusCmd = &cobra.Command{
 	Short: "Show status",
 	Long:  "Show status",
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := globalConfigLoader.load()
+		conf, err := globalConfigLoader.load(true)
 		if err != nil {
 			util.Exit(1, "Failed to load configuration: %s\n", err)
 		}

--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func runUnlockCmd(cmd *cobra.Command, args []string) {
-	conf, err := globalConfigLoader.load()
+	conf, err := globalConfigLoader.load(true)
 	if err != nil {
 		util.Exit(1, "Failed to load configuration: %s\n", err)
 	}

--- a/collector/block_collector.go
+++ b/collector/block_collector.go
@@ -22,6 +22,7 @@ type BlockCollector struct {
 	log log.Logger
 }
 
+// Deprecated:
 func NewBlockCollector(
 	cfg *config.Verifier,
 	db *database.Database,

--- a/collector/event_collector.go
+++ b/collector/event_collector.go
@@ -71,7 +71,7 @@ func (w *EventCollector) Work(ctx context.Context) {
 
 		// collect event logs from hub-layer
 		start, end := blocks[0], blocks[len(blocks)-1]
-		logs, err := w.hub.FilterLogs(ctx, verse.NewEventLogFilter(start.Number, end.Number))
+		logs, err := w.hub.FilterLogs(ctx, verse.NewEventLogFilter(start.Number, end.Number, nil))
 		if err != nil {
 			w.log.Error("Failed to fetch event logs from hub-layer",
 				"start", start, "end", end, "err", err)

--- a/collector/event_collector.go
+++ b/collector/event_collector.go
@@ -24,6 +24,7 @@ type EventCollector struct {
 	log    log.Logger
 }
 
+// Deprecated:
 func NewEventCollector(
 	cfg *config.Verifier,
 	db *database.Database,

--- a/config/config.go
+++ b/config/config.go
@@ -72,14 +72,14 @@ func Defaults() map[string]interface{} {
 		"verifier.state_collect_limit":   1000,
 		"verifier.state_collect_timeout": 15 * time.Second,
 		"verifier.db_optimize_interval":  time.Hour,
-		"verifier.confirmations":         3, // 3 confirmations are enough for the current L1.
+		"verifier.confirmations":         3, // 3 confirmations are enough for later than v1.3.0 L1.
 
 		// The minimum interval for Verse v0 is 15 seconds.
 		// On the other hand, the minimum interval for Verse v1 is 80 seconds.
 		// Balance the two by setting the default to 30 seconds.
 		"submitter.interval":              30 * time.Second,
 		"submitter.concurrency":           50,
-		"submitter.confirmations":         3, // 3 confirmations are enough for the current L1.
+		"submitter.confirmations":         3, // 3 confirmations are enough for later than v1.3.0 L1.
 		"submitter.gas_multiplier":        1.1,
 		"submitter.batch_size":            20,
 		"submitter.max_gas":               5_000_000,

--- a/config/config.go
+++ b/config/config.go
@@ -161,9 +161,9 @@ func Validate(conf *Config) error {
 		return errors.New("either verse_layer.discovery.endpoint or verse_layer.directs must be set")
 	}
 	// validate verifier and submitter configuration
-	// if !conf.Verifier.Enable && !conf.Submitter.Enable {
-	// 	return errors.New("either verifier.enable or submitter.enable must be set")
-	// }
+	if !conf.Verifier.Enable && !conf.Submitter.Enable {
+		return errors.New("either verifier.enable or submitter.enable must be set")
+	}
 	return validate.Struct(conf)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -165,10 +165,11 @@ func Validate(conf *Config, strict bool) error {
 		if conf.VerseLayer.Discovery.Endpoint == "" && len(conf.VerseLayer.Directs) == 0 {
 			return errors.New("either verse.discovery or verse.directs must be set")
 		}
+		// NOTE: Commented out because bootnode disable verifier and submitter
 		// validate verifier and submitter configuration
-		if !conf.Verifier.Enable && !conf.Submitter.Enable {
-			return errors.New("either verifier.enable or submitter.enable must be set")
-		}
+		// if !conf.Verifier.Enable && !conf.Submitter.Enable {
+		// 	return errors.New("either verifier.enable or submitter.enable must be set")
+		// }
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,10 +72,14 @@ func Defaults() map[string]interface{} {
 		"verifier.state_collect_limit":   1000,
 		"verifier.state_collect_timeout": 15 * time.Second,
 		"verifier.db_optimize_interval":  time.Hour,
+		"verifier.confirmations":         3, // 3 confirmations are enough for the current L1.
 
-		"submitter.interval":              15 * time.Second,
+		// The minimum interval for Verse v0 is 15 seconds.
+		// On the other hand, the minimum interval for Verse v1 is 80 seconds.
+		// Balance the two by setting the default to 30 seconds.
+		"submitter.interval":              30 * time.Second,
 		"submitter.concurrency":           50,
-		"submitter.confirmations":         6,
+		"submitter.confirmations":         3, // 3 confirmations are enough for the current L1.
 		"submitter.gas_multiplier":        1.1,
 		"submitter.batch_size":            20,
 		"submitter.max_gas":               5_000_000,
@@ -375,6 +379,9 @@ type Verifier struct {
 
 	// Interval to optimize database.
 	OptimizeInterval time.Duration `koanf:"db_optimize_interval"`
+
+	// Number of confirmation blocks for transaction receipt.
+	Confirmations int
 }
 
 type Submitter struct {

--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,8 @@ func Defaults() map[string]interface{} {
 		"verifier.state_collect_limit":   1000,
 		"verifier.state_collect_timeout": 15 * time.Second,
 		"verifier.db_optimize_interval":  time.Hour,
-		"verifier.confirmations":         3, // 3 confirmations are enough for later than v1.3.0 L1.
+		"verifier.confirmations":         3,                // 3 confirmations are enough for later than v1.3.0 L1.
+		"verifier.start_block_offset":    uint64(5760 * 2), // 2 days
 
 		// The minimum interval for Verse v0 is 15 seconds.
 		// On the other hand, the minimum interval for Verse v1 is 80 seconds.
@@ -396,6 +397,10 @@ type Verifier struct {
 
 	// Number of confirmation blocks for transaction receipt.
 	Confirmations int
+
+	// The number of start fetching events is offset from the current block.
+	// This offset is used at the first time to fetch events.
+	StartBlockOffset uint64 `koanf:"start_block_offset"`
 }
 
 type Submitter struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -155,6 +156,14 @@ func MustNewDefaultConfig() *Config {
 }
 
 func Validate(conf *Config) error {
+	// validate verse discovery configuration
+	if conf.VerseLayer.Discovery.Endpoint == "" && len(conf.VerseLayer.Directs) == 0 {
+		return errors.New("either verse_layer.discovery.endpoint or verse_layer.directs must be set")
+	}
+	// validate verifier and submitter configuration
+	// if !conf.Verifier.Enable && !conf.Submitter.Enable {
+	// 	return errors.New("either verifier.enable or submitter.enable must be set")
+	// }
 	return validate.Struct(conf)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -295,7 +295,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 		},
 	}
 
-	got, _ := NewConfig(s.toBytes(input))
+	got, _ := NewConfig(s.toBytes(input), false)
 
 	s.Equal(want, got)
 }
@@ -343,7 +343,7 @@ func (s *ConfigTestSuite) TestValidate() {
 		"Config.metrics.listen":                            "hostname_port",
 	}
 
-	_, err := NewConfig(s.toBytes(input))
+	_, err := NewConfig(s.toBytes(input), false)
 
 	gots := map[string]string{}
 	for _, e := range err.(validator.ValidationErrors) {
@@ -373,7 +373,8 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 		listen: 127.0.0.1:20001
 	`)
 
-	got, _ := NewConfig(s.toBytes(input))
+	got, err := NewConfig(s.toBytes(input), false)
+	s.NoError(err)
 
 	s.Equal(time.Hour, got.VerseLayer.Discovery.RefreshInterval)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,11 +28,11 @@ func (s *ConfigTestSuite) TestNewConfig() {
 			address: '0xBA3186c30Bb0d9e8c7924147238F82617C3fE729'
 			password: /etc/passwd
 			plain: '0x70ce1ba0e76547883c0999662d093dd3426d550ec783a6c775b0060bf4ee6d0f'
-	
+
 	hub_layer:
 		chain_id: 12345
 		rpc: http://127.0.0.1:8545/
-	
+
 	verse_layer:
 		discovery:
 			endpoint: http://127.0.0.1/api/v1/verse-layers.json
@@ -43,7 +43,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 			  rpc: http://127.0.0.1:8545/
 			  l1_contracts:
 			    StateCommitmentChain: '0x62b105FD57A11819f9E50892E18a354bd7c89937'
-	
+
 	p2p:
 		listens:
 			- listen0
@@ -80,7 +80,8 @@ func (s *ConfigTestSuite) TestNewConfig() {
 		state_collect_limit: 5
 		state_collect_timeout: 1s
 		db_optimize_interval: 2s
-	
+		confirmations: 4
+
 	submitter:
 		enable: true
 		interval: 5s
@@ -240,6 +241,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 			StateCollectLimit:   5,
 			StateCollectTimeout: time.Second,
 			OptimizeInterval:    time.Second * 2,
+			Confirmations:       4,
 		},
 		Submitter: Submitter{
 			Enable:              true,
@@ -358,15 +360,15 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 	input := (`
 	datastore: /tmp
 	keystore: /tmp
-	
+
 	hub_layer:
 		chain_id: 12345
 		rpc: http://127.0.0.1:8545/
-	
+
 	verse_layer:
 		discovery:
 			endpoint: http://127.0.0.1/
-	
+
 	p2p:
 		listen: 127.0.0.1:20001
 	`)
@@ -409,10 +411,11 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 	s.Equal(1000, got.Verifier.StateCollectLimit)
 	s.Equal(15*time.Second, got.Verifier.StateCollectTimeout)
 	s.Equal(time.Hour, got.Verifier.OptimizeInterval)
+	s.Equal(3, got.Verifier.Confirmations)
 
-	s.Equal(15*time.Second, got.Submitter.Interval)
+	s.Equal(30*time.Second, got.Submitter.Interval)
 	s.Equal(50, got.Submitter.Concurrency)
-	s.Equal(6, got.Submitter.Confirmations)
+	s.Equal(3, got.Submitter.Confirmations)
 	s.Equal(1.1, got.Submitter.GasMultiplier)
 	s.Equal(20, got.Submitter.BatchSize)
 	s.Equal(uint64(5_000_000), got.Submitter.MaxGas)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,6 +81,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 		state_collect_timeout: 1s
 		db_optimize_interval: 2s
 		confirmations: 4
+		start_block_offset: 5760
 
 	submitter:
 		enable: true
@@ -242,6 +243,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 			StateCollectTimeout: time.Second,
 			OptimizeInterval:    time.Second * 2,
 			Confirmations:       4,
+			StartBlockOffset:    5760,
 		},
 		Submitter: Submitter{
 			Enable:              true,

--- a/config/verse_discovery.go
+++ b/config/verse_discovery.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -33,9 +32,10 @@ func NewVerseDiscovery(
 		topic:           util.NewTopic(),
 		log:             log.New("worker", "verse-discovery"),
 	}
-	if _, err = disc.fetch(ctx); err != nil {
-		return nil, fmt.Errorf("the inital verse discovery failed, make sure the url(%s) is reachable: %w", url, err)
-	}
+	// Commented out the initial fetch, as it will be done in the worker
+	// if _, err = disc.fetch(ctx); err != nil {
+	// 	return nil, fmt.Errorf("the inital verse discovery failed, make sure the url(%s) is reachable: %w", url, err)
+	// }
 	return
 }
 

--- a/config/verse_discovery.go
+++ b/config/verse_discovery.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -20,17 +21,22 @@ type VerseDiscovery struct {
 }
 
 func NewVerseDiscovery(
+	ctx context.Context,
 	client *http.Client,
 	url string,
 	refreshInterval time.Duration,
-) *VerseDiscovery {
-	return &VerseDiscovery{
+) (disc *VerseDiscovery, err error) {
+	disc = &VerseDiscovery{
 		client:          client,
 		url:             url,
 		refreshInterval: refreshInterval,
 		topic:           util.NewTopic(),
 		log:             log.New("worker", "verse-discovery"),
 	}
+	if _, err = disc.fetch(ctx); err != nil {
+		return nil, fmt.Errorf("the inital verse discovery failed, make sure the url(%s) is reachable: %w", url, err)
+	}
+	return
 }
 
 func (w *VerseDiscovery) Subscribe(ctx context.Context) *VerseSubscription {

--- a/config/verse_discovery_test.go
+++ b/config/verse_discovery_test.go
@@ -50,7 +50,8 @@ func (s *VerseDiscoveryTestSuite) TestDiscover() {
 	})
 
 	// setup pubsub
-	discovery := NewVerseDiscovery(client, "https://example.com/", time.Second)
+	discovery, err := NewVerseDiscovery(context.Background(), client, "https://example.com/", time.Second)
+	s.Require().NoError(err)
 	sub0 := discovery.Subscribe(context.Background())
 	sub1 := discovery.Subscribe(context.Background())
 

--- a/database/op_event.go
+++ b/database/op_event.go
@@ -14,12 +14,12 @@ type OPEvent interface {
 	idCol() string
 	contractCol() string
 	rollupIndexCol() string
-	assignEvent(contract *OptimismContract, e any) error
 
 	Logger(base log.Logger) log.Logger
 	GetContract() *OptimismContract
 	GetRollupIndex() uint64
 	GetRollupHash() common.Hash
+	AssignEvent(contract *OptimismContract, e any) error
 }
 
 type OPEventConstraint[X any] interface {
@@ -131,7 +131,7 @@ func (db *OPEventDB[T, PT]) Save(contract common.Address, e any) (OPEvent, error
 	err := db.db.Transaction(func(txdb *Database) error {
 		if c, err := txdb.OPContract.FindOrCreate(contract); err != nil {
 			return err
-		} else if err := row.assignEvent(c, e); err != nil {
+		} else if err := row.AssignEvent(c, e); err != nil {
 			return err
 		}
 		return txdb.rawdb.Create(&row).Error

--- a/database/op_proposal.go
+++ b/database/op_proposal.go
@@ -43,7 +43,7 @@ func (row *OpstackProposal) GetRollupHash() common.Hash {
 	return crypto.Keccak256Hash(msg)
 }
 
-func (row *OpstackProposal) assignEvent(contract *OptimismContract, e any) error {
+func (row *OpstackProposal) AssignEvent(contract *OptimismContract, e any) error {
 	t, ok := e.(*l2oo.OasysL2OutputOracleOutputProposed)
 	if !ok {
 		return errors.New("invalid event")

--- a/database/op_signature.go
+++ b/database/op_signature.go
@@ -150,6 +150,7 @@ func (db *OptimismSignatureDB) FindUnverifiedBySigner(
 		Joins("Contract").
 		Where("optimism_signatures.signer_id = ?", _signer.ID).
 		Where("optimism_signatures.batch_index >= ?", unverifiedIndex).
+		Order("optimism_signatures.batch_index").
 		Limit(limit)
 
 	if contract != nil {

--- a/database/op_signature.go
+++ b/database/op_signature.go
@@ -132,6 +132,7 @@ func (db *OptimismSignatureDB) FindUnverifiedBySigner(
 	signer common.Address,
 	unverifiedIndex uint64,
 	contract *common.Address,
+	limit int,
 ) ([]*OptimismSignature, error) {
 	_signer, err := db.db.Signer.FindOrCreate(signer)
 	if err != nil {
@@ -143,7 +144,8 @@ func (db *OptimismSignatureDB) FindUnverifiedBySigner(
 		Joins("Contract").
 		Where("optimism_signatures.signer_id = ?", _signer.ID).
 		Order("optimism_signatures.id DESC").
-		Where("optimism_signatures.batch_index >= ?", unverifiedIndex)
+		Where("optimism_signatures.batch_index >= ?", unverifiedIndex).
+		Limit(limit)
 
 	if contract != nil {
 		_contract, err := db.db.OPContract.FindOrCreate(*contract)

--- a/database/op_signature.go
+++ b/database/op_signature.go
@@ -131,20 +131,29 @@ func (db *OptimismSignatureDB) FindLatestsBySigner(
 func (db *OptimismSignatureDB) FindUnverifiedBySigner(
 	signer common.Address,
 	unverifiedIndex uint64,
+	contract *common.Address,
 ) ([]*OptimismSignature, error) {
 	_signer, err := db.db.Signer.FindOrCreate(signer)
 	if err != nil {
 		return nil, err
 	}
 
-	var rows []*OptimismSignature
 	tx := db.rawdb.
 		Joins("Signer").
 		Joins("Contract").
 		Where("optimism_signatures.signer_id = ?", _signer.ID).
 		Order("optimism_signatures.id DESC").
-		Where("optimism_signatures.batch_index >= ?", unverifiedIndex).
-		Find(&rows)
+		Where("optimism_signatures.batch_index >= ?", unverifiedIndex)
+
+	if contract != nil {
+		_contract, err := db.db.OPContract.FindOrCreate(*contract)
+		if err != nil {
+			return nil, err
+		}
+		tx = tx.Where("optimism_signatures.optimism_scc_id = ?", _contract.ID)
+	}
+	var rows []*OptimismSignature
+	tx = tx.Find(&rows)
 
 	if tx.Error != nil {
 		return nil, tx.Error

--- a/database/op_state.go
+++ b/database/op_state.go
@@ -36,7 +36,7 @@ func (row *OptimismState) GetRollupHash() common.Hash {
 	return row.BatchRoot
 }
 
-func (row *OptimismState) assignEvent(contract *OptimismContract, e any) error {
+func (row *OptimismState) AssignEvent(contract *OptimismContract, e any) error {
 	t, ok := e.(*scc.SccStateBatchAppended)
 	if !ok {
 		return errors.New("invalid event")

--- a/ethutil/client.go
+++ b/ethutil/client.go
@@ -2,6 +2,7 @@ package ethutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -18,6 +19,10 @@ import (
 	"github.com/lmittmann/w3/module/eth"
 	"github.com/lmittmann/w3/w3types"
 	"golang.org/x/sync/semaphore"
+)
+
+var (
+	ErrTooManyRequests = errors.New("too many requests")
 )
 
 type SignDataFn = func(hash []byte) (sig []byte, err error)
@@ -96,6 +101,7 @@ func (c *client) FilterLogsWithRateThottling(ctx context.Context, q ethereum.Fil
 	if err != nil && strings.Contains(err.Error(), "too many requests") {
 		// sleep longer if the rate limit is reached.
 		time.Sleep(3 * time.Second)
+		err = fmt.Errorf("%w: %v", ErrTooManyRequests, err)
 		return
 	}
 

--- a/ethutil/client.go
+++ b/ethutil/client.go
@@ -99,8 +99,8 @@ func (c *client) FilterLogsWithRateThottling(ctx context.Context, q ethereum.Fil
 		return
 	}
 
-	// sleep if the filter range is big.
-	if 1024 <= q.ToBlock.Sub(q.ToBlock, q.FromBlock).Uint64() {
+	// sleep if the filter range is big or not set.
+	if q.ToBlock == nil || q.FromBlock == nil || 1024 <= q.ToBlock.Sub(q.ToBlock, q.FromBlock).Uint64() {
 		time.Sleep(300 * time.Microsecond)
 	}
 

--- a/ethutil/client.go
+++ b/ethutil/client.go
@@ -2,8 +2,12 @@ package ethutil
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"strings"
+	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -13,6 +17,7 @@ import (
 	"github.com/lmittmann/w3"
 	"github.com/lmittmann/w3/module/eth"
 	"github.com/lmittmann/w3/w3types"
+	"golang.org/x/sync/semaphore"
 )
 
 type SignDataFn = func(hash []byte) (sig []byte, err error)
@@ -27,6 +32,7 @@ type Client interface {
 		ctx context.Context,
 		hash common.Hash,
 	) (tx *types.Transaction, isPending bool, err error)
+	FilterLogsWithRateThottling(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	NewBatchHeaderClient() (BatchHeaderClient, error)
 	GetProof(ctx context.Context, account common.Address, keys []string, blockNumber *big.Int) (*gethclient.AccountResult, error)
 }
@@ -46,6 +52,8 @@ type client struct {
 
 	url string
 	rpc *rpc.Client
+	// used for api rate thottling.
+	sem *semaphore.Weighted
 }
 
 func NewClient(url string) (Client, error) {
@@ -54,10 +62,14 @@ func NewClient(url string) (Client, error) {
 		return nil, err
 	}
 
+	// This is magic number, it should be updated based on the network.
+	// semaphore is used for log filtering rate thottling for now.
+	const concurrency = 2
 	return &client{
 		Client: ethclient.NewClient(c),
 		url:    url,
 		rpc:    c,
+		sem:    semaphore.NewWeighted(concurrency),
 	}, nil
 }
 
@@ -70,6 +82,29 @@ func (c *client) TransactionByHash(
 	hash common.Hash,
 ) (tx *types.Transaction, isPending bool, err error) {
 	return c.Client.TransactionByHash(ctx, hash)
+}
+
+func (c *client) FilterLogsWithRateThottling(ctx context.Context, q ethereum.FilterQuery) (logs []types.Log, err error) {
+	if err = c.sem.Acquire(ctx, 1); err != nil {
+		// continue even if we can't acquire semaphore.
+		fmt.Printf("***** WARN *****\nfailed to acquire semaphore in filter: %v\n", err)
+	} else {
+		defer c.sem.Release(1)
+	}
+
+	logs, err = c.Client.FilterLogs(ctx, q)
+	if err != nil && strings.Contains(err.Error(), "too many requests") {
+		// sleep longer if the rate limit is reached.
+		time.Sleep(3 * time.Second)
+		return
+	}
+
+	// sleep if the filter range is big.
+	if 1024 <= q.ToBlock.Sub(q.ToBlock, q.FromBlock).Uint64() {
+		time.Sleep(300 * time.Microsecond)
+	}
+
+	return
 }
 
 func (c *client) NewBatchHeaderClient() (BatchHeaderClient, error) {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -205,41 +205,6 @@ func (w *Node) Host() host.Host                  { return w.h }
 func (w *Node) Routing() routing.Routing         { return w.dht }
 func (w *Node) HolePunchHelper() HolePunchHelper { return w.hpHelper }
 
-func (w *Node) meterLoop(ctx context.Context) {
-	ticker := time.NewTicker(time.Second * 15)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			nwstat := newNetworkStatus(w.h)
-			w.meterTCPConnections.Set(float64(nwstat.connections.tcp))
-			w.meterUDPConnections.Set(float64(nwstat.connections.udp))
-			w.meterRelayConnections.Set(float64(nwstat.connections.relay))
-			w.meterRelayHopStreams.Set(float64(nwstat.streams.hop))
-			w.meterRelayStopStreams.Set(float64(nwstat.streams.stop))
-			w.meterVerifierStreams.Set(float64(nwstat.streams.verifier))
-			w.meterPeers.Set(float64(w.h.Peerstore().Peers().Len()))
-		}
-	}
-}
-
-func (w *Node) publishLoop(ctx context.Context) {
-	ticker := time.NewTicker(w.cfg.PublishInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			w.publishLatestSignatures(ctx)
-		}
-	}
-}
-
 func (w *Node) subscribeLoop(ctx context.Context) {
 	type job struct {
 		ctx    context.Context

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -721,8 +721,6 @@ func (w *Node) PublishSignatures(ctx context.Context, rows []*database.OptimismS
 		w.log.Error("Failed to publish latest signatures", "err", err)
 		return
 	}
-
-	w.log.Info("Publish latest signatures", "len", len(rows))
 }
 
 func (w *Node) openStream(ctx context.Context, peer peer.ID) (network.Stream, error) {

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -319,7 +319,7 @@ func (s *NodeTestSuite) TestHandleOptimismSignatureExchangeFromPubSub2() {
 	// saving too old signature (no pruneRollupIndexDepth)
 	msg = toProtoBufSig(s.sigs[s.signer0][s.contract0][0])
 	saved = s.node2.handleOptimismSignatureExchangeFromPubSub2(context.Background(), s.node1.h.ID(), msg)
-	s.False(saved)
+	s.True(saved)
 }
 
 func (s *NodeTestSuite) TestHandleOptimismSignatureExchangeRequests() {

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/oasysgames/oasys-optimism-verifier/testhelper"
 	"github.com/oasysgames/oasys-optimism-verifier/testhelper/backend"
 	"github.com/oasysgames/oasys-optimism-verifier/util"
-	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -137,188 +136,21 @@ func (s *NodeTestSuite) SetupTest() {
 }
 
 func (s *NodeTestSuite) TestHandleOptimismSignatureExchangeFromPubSub() {
-	type want struct {
-		signer  common.Address
-		idAfter string
-	}
-	type testcase struct {
-		msg  *pb.OptimismSignature
-		want want
-	}
-	cases := []*testcase{
-		{
-			toProtoBufSig(s.sigs[s.signer0][s.contract1][99]),
-			want{s.signer0, s.sigs[s.signer0][s.contract1][99].ID},
-		},
-		{
-			toProtoBufSig(s.sigs[s.signer1][s.contract1][199]),
-			want{s.signer1, s.sigs[s.signer1][s.contract1][199].ID},
-		},
-		{
-			&pb.OptimismSignature{
-				Id:          util.ULID(nil).String(),
-				PreviousId:  util.ULID(nil).String(),
-				Signer:      s.signer2[:],
-				Contract:    s.contract2[:],
-				RollupIndex: 0,
-				RollupHash:  s.genStateRoot(s.contract2[:], 0).Bytes(),
-				Approved:    true,
-			},
-			want{s.signer2, ""},
-		},
-	}
-
-	lastcase := cases[len(cases)-1]
-	msg := ethutil.NewMessage(
-		s.b2.ChainID(),
-		common.BytesToAddress(lastcase.msg.Contract),
-		new(big.Int).SetUint64(lastcase.msg.RollupIndex),
-		util.BytesToBytes32(lastcase.msg.RollupHash),
-		lastcase.msg.Approved,
-	)
-	sigbin, _ := msg.Signature(s.b2.SignData)
-	lastcase.msg.Signature = sigbin[:]
-
-	// set assertion func to subscriber
-	var (
-		reads = []*pb.Stream{}
-		wg    sync.WaitGroup
-	)
-	wg.Add(len(cases))
-	s.node2.h.SetStreamHandler(streamProtocol, func(st network.Stream) {
-		defer wg.Done()
-		defer closeStream(st)
-
-		for {
-			m, _ := readStream(st)
-			reads = append(reads, m)
-
-			switch m.Body.(type) {
-			case *pb.Stream_FindCommonOptimismSignature:
-				writeStream(st, &pb.Stream{Body: &pb.Stream_FindCommonOptimismSignature{
-					FindCommonOptimismSignature: &pb.FindCommonOptimismSignature{
-						Found: nil,
-					},
-				}})
-			case *pb.Stream_OptimismSignatureExchange:
-				writeStream(st, eom)
-			case *pb.Stream_Eom:
-				return
-			}
-		}
-	})
-
-	// publish message
-	for _, tt := range cases {
-		go s.node1.handleOptimismSignatureExchangeFromPubSub(context.Background(), s.node2.h.ID(), tt.msg)
-		time.Sleep(time.Millisecond * 50)
-	}
-	wg.Wait()
-
-	s.Len(reads, 16)
-
-	// signer0
-	gots0 := reads[0].GetFindCommonOptimismSignature().Locals
-	s.Len(gots0, 50)
-	s.Equal(gots0[0].Id, s.sigs[s.signer0][s.contract1][99].ID)
-	s.Equal(gots0[49].Id, s.sigs[s.signer0][s.contract1][50].ID)
-
-	gots1 := reads[1].GetFindCommonOptimismSignature().Locals
-	s.Len(gots1, 50)
-	s.Equal(gots1[0].Id, s.sigs[s.signer0][s.contract1][49].ID)
-	s.Equal(gots1[49].Id, s.sigs[s.signer0][s.contract1][0].ID)
-
-	gots2 := reads[2].GetFindCommonOptimismSignature().Locals
-	s.Len(gots2, 50)
-	s.Equal(gots2[0].Id, s.sigs[s.signer0][s.contract0][49].ID)
-	s.Equal(gots2[49].Id, s.sigs[s.signer0][s.contract0][0].ID)
-
-	gots3 := reads[3].GetOptimismSignatureExchange().Requests
-	s.Len(gots3, 1)
-	s.Equal(cases[0].want.signer[:], gots3[0].Signer)
-	func() {
-		gt := ulid.MustParse(gots3[0].IdAfter)
-		wt := ulid.MustParse(cases[0].want.idAfter)
-		s.Equal(wt.Time()-1000, gt.Time())
-	}()
-
-	gots4 := reads[4].GetEom()
-	s.NotNil(gots4)
-
-	// signer1
-	gots5 := reads[5].GetFindCommonOptimismSignature().Locals
-	s.Len(gots5, 50)
-	s.Equal(gots5[0].Id, s.sigs[s.signer1][s.contract1][199].ID)
-	s.Equal(gots5[49].Id, s.sigs[s.signer1][s.contract1][150].ID)
-
-	gots6 := reads[6].GetFindCommonOptimismSignature().Locals
-	s.Len(gots6, 50)
-	s.Equal(gots6[0].Id, s.sigs[s.signer1][s.contract1][149].ID)
-	s.Equal(gots6[49].Id, s.sigs[s.signer1][s.contract1][100].ID)
-
-	gots7 := reads[7].GetFindCommonOptimismSignature().Locals
-	s.Len(gots7, 50)
-	s.Equal(gots7[0].Id, s.sigs[s.signer1][s.contract1][99].ID)
-	s.Equal(gots7[49].Id, s.sigs[s.signer1][s.contract1][50].ID)
-
-	gots8 := reads[8].GetFindCommonOptimismSignature().Locals
-	s.Len(gots8, 50)
-	s.Equal(gots8[0].Id, s.sigs[s.signer1][s.contract1][49].ID)
-	s.Equal(gots8[49].Id, s.sigs[s.signer1][s.contract1][0].ID)
-
-	gots9 := reads[9].GetFindCommonOptimismSignature().Locals
-	s.Len(gots9, 50)
-	s.Equal(gots9[0].Id, s.sigs[s.signer1][s.contract0][149].ID)
-	s.Equal(gots9[49].Id, s.sigs[s.signer1][s.contract0][100].ID)
-
-	gots10 := reads[10].GetFindCommonOptimismSignature().Locals
-	s.Len(gots10, 50)
-	s.Equal(gots10[0].Id, s.sigs[s.signer1][s.contract0][99].ID)
-	s.Equal(gots10[49].Id, s.sigs[s.signer1][s.contract0][50].ID)
-
-	gots11 := reads[11].GetFindCommonOptimismSignature().Locals
-	s.Len(gots11, 50)
-	s.Equal(gots11[0].Id, s.sigs[s.signer1][s.contract0][49].ID)
-	s.Equal(gots11[49].Id, s.sigs[s.signer1][s.contract0][0].ID)
-
-	gots12 := reads[12].GetOptimismSignatureExchange().Requests
-	s.Len(gots12, 1)
-	s.Equal(cases[1].want.signer[:], gots12[0].Signer)
-	func() {
-		gt := ulid.MustParse(gots12[0].IdAfter)
-		wt := ulid.MustParse(cases[1].want.idAfter)
-		s.Equal(wt.Time()-1000, gt.Time())
-	}()
-
-	gots13 := reads[13].GetEom()
-	s.NotNil(gots13)
-
-	// signer2
-	gots14 := reads[14].GetOptimismSignatureExchange().Requests
-	s.Len(gots14, 1)
-	s.Equal(cases[2].want.signer[:], gots14[0].Signer)
-	s.Equal("", gots14[0].IdAfter)
-
-	gots15 := reads[15].GetEom()
-	s.NotNil(gots15)
-}
-
-func (s *NodeTestSuite) TestHandleOptimismSignatureExchangeFromPubSub2() {
 	// succeed to save signature
 	msg := toProtoBufSig(s.sigs[s.signer0][s.contract0][49])
-	saved := s.node2.handleOptimismSignatureExchangeFromPubSub2(context.Background(), s.node1.h.ID(), msg)
+	saved := s.node2.handleOptimismSignatureExchangeFromPubSub(context.Background(), s.node1.h.ID(), msg)
 	s.True(saved)
 	got, err := s.node2.db.OPSignature.FindByID(msg.Id)
 	s.NoError(err)
 	s.Equal(msg.Id, got.ID)
 
 	// saving duplicate signature
-	saved = s.node2.handleOptimismSignatureExchangeFromPubSub2(context.Background(), s.node1.h.ID(), msg)
+	saved = s.node2.handleOptimismSignatureExchangeFromPubSub(context.Background(), s.node1.h.ID(), msg)
 	s.False(saved)
 
 	// saving too old signature (no pruneRollupIndexDepth)
 	msg = toProtoBufSig(s.sigs[s.signer0][s.contract0][0])
-	saved = s.node2.handleOptimismSignatureExchangeFromPubSub2(context.Background(), s.node1.h.ID(), msg)
+	saved = s.node2.handleOptimismSignatureExchangeFromPubSub(context.Background(), s.node1.h.ID(), msg)
 	s.True(saved)
 }
 

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -7,7 +7,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -347,7 +347,7 @@ func decompress(b []byte) ([]byte, error) {
 	if err = r.Close(); err != nil {
 		return nil, err
 	}
-	if b, err = ioutil.ReadAll(r); err != nil {
+	if b, err = io.ReadAll(r); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/proto/.clang-format
+++ b/proto/.clang-format
@@ -1,0 +1,6 @@
+---
+Language: Proto
+BasedOnStyle: Google
+ColumnLimit: 1024
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true

--- a/proto/p2p/v1/message.proto
+++ b/proto/p2p/v1/message.proto
@@ -6,53 +6,53 @@ option go_package = "./gen";
 
 message PubSub {
   oneof body {
-    bytes misc = 1;
+    bytes                     misc                        = 1;
     OptimismSignatureExchange optimism_signature_exchange = 2;
   }
 }
 
 message Stream {
   oneof body {
-    bytes misc = 1;
-    bytes eom = 2;
-    OptimismSignatureExchange optimism_signature_exchange = 3;
+    bytes                       misc                           = 1;
+    bytes                       eom                            = 2;
+    OptimismSignatureExchange   optimism_signature_exchange    = 3;
     FindCommonOptimismSignature find_common_optimism_signature = 4;
   }
 }
 
 message OptimismSignature {
-  string id = 1;
-  string previous_id = 2;
-  bytes signer = 3;
-  bytes contract = 4;
+  string id           = 1;
+  string previous_id  = 2;
+  bytes  signer       = 3;
+  bytes  contract     = 4;
   uint64 rollup_index = 5;
-  bytes rollup_hash = 6;
-  bool approved = 10;
-  bytes signature = 11;
+  bytes  rollup_hash  = 6;
+  bool   approved     = 10;
+  bytes  signature    = 11;
 
   // These are fields that do not exist in OPStack and will be removed.
-  uint64 batch_size = 7 [ deprecated = true ];
-  uint64 prev_total_elements = 8 [ deprecated = true ];
-  bytes extra_data = 9 [ deprecated = true ];
+  uint64 batch_size          = 7 [deprecated = true];
+  uint64 prev_total_elements = 8 [deprecated = true];
+  bytes  extra_data          = 9 [deprecated = true];
 }
 
 message OptimismSignatureExchange {
-  repeated OptimismSignature latests = 1;
-  repeated Request requests = 2;
+  repeated OptimismSignature latests   = 1;
+  repeated Request           requests  = 2;
   repeated OptimismSignature responses = 3;
 
   message Request {
-    bytes signer = 1;
+    bytes  signer   = 1;
     string id_after = 2;
   }
 }
 
 message FindCommonOptimismSignature {
-  repeated Local locals = 1;
-  optional OptimismSignature found = 2;
+  repeated Local             locals = 1;
+  optional OptimismSignature found  = 2;
 
   message Local {
-    string id = 1;
+    string id          = 1;
     string previous_id = 2;
   }
 }

--- a/submitter/signature_iter.go
+++ b/submitter/signature_iter.go
@@ -109,3 +109,8 @@ func (err *StakeAmountShortage) Error() string {
 	return fmt.Sprintf("stake amount shortage, required=%s actual=%s",
 		fromWei(err.required), fromWei(err.actual))
 }
+
+func (err *StakeAmountShortage) Is(target error) bool {
+	_, ok := target.(*StakeAmountShortage)
+	return ok
+}

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -70,16 +70,15 @@ func (w *Submitter) Start(ctx context.Context) {
 	w.workLoop(ctx)
 }
 
-func (w *Submitter) AddVerse(ctx context.Context, verse verse.TransactableVerse) {
+func (w *Submitter) AddVerse(ctx context.Context, v verse.TransactableVerse, chainId uint64) {
 	// Start submitting loop
 	// 1. Request signatures every interval
 	// 2. Submit verify tx if enough signatures are collected
-	go w.startSubmitter(ctx, verse)
+	go w.startSubmitter(ctx, v, chainId)
 }
 
-func (w *Submitter) startSubmitter(ctx context.Context, v verse.TransactableVerse) {
+func (w *Submitter) startSubmitter(ctx context.Context, v verse.TransactableVerse, chainId uint64) {
 	var (
-		chainId       = v.L1Signer().ChainID().Uint64()
 		tick          = time.NewTicker(w.cfg.Interval)
 		duration      = w.cfg.Interval
 		verifiedIndex *uint64

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -127,6 +127,7 @@ func (w *Submitter) startSubmitter(ctx context.Context, v verse.TransactableVers
 				continue
 			} else if errors.Is(err, ErrAlreadyVerified) {
 				// Skip if the nextIndex is already verified
+				w.log.Info("Already verified the rollup index", "nextIndex", nextIndex, "chainId", chainId)
 				continue
 			} else {
 				w.log.Error("Failed to verify the rollup index", "nextIndex", nextIndex, "chainId", chainId, "err", err)

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -103,7 +103,7 @@ func (w *Submitter) startSubmitter(ctx context.Context, v verse.TransactableVers
 				w.log.Info("Not enough confirmations", "nextIndex", nextIndex, "chainId", chainId)
 				continue
 			} else if errors.Is(err, ErrNoSignatures) {
-				w.log.Info("No signatures", "nextIndex", nextIndex, "chainId", chainId)
+				w.log.Info("No signatures to submit", "nextIndex", nextIndex, "chainId", chainId)
 				// Reset the ticker to the original interval
 				resetDuration(w.cfg.Interval)
 				continue

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -189,7 +189,6 @@ func (w *Submitter) HasTask(contract common.Address) bool {
 }
 
 func (w *Submitter) AddTask(ctx context.Context, task verse.TransactableVerse, chainId uint64) {
-	task.Logger(w.log).Info("Add submitter task")
 	exists := w.HasTask(task.RollupContract())
 	w.tasks.Store(task.RollupContract(), task)
 	if !exists {

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -191,9 +191,10 @@ func (w *Submitter) HasTask(contract common.Address) bool {
 	return ok
 }
 
-func (w *Submitter) AddTask(task verse.TransactableVerse) {
+func (w *Submitter) AddTask(ctx context.Context, task verse.TransactableVerse, chainId uint64) {
 	task.Logger(w.log).Info("Add submitter task")
 	w.tasks.Store(task.RollupContract(), task)
+	w.AddVerse(ctx, task, chainId)
 }
 
 func (w *Submitter) RemoveTask(contract common.Address) {

--- a/submitter/submitter_test.go
+++ b/submitter/submitter_test.go
@@ -44,9 +44,9 @@ func (s *SubmitterTestSuite) SetupTest() {
 
 	// Setup submitter
 	s.submitter = NewSubmitter(&config.Submitter{
-		Interval:         0,
+		Interval:         100 * time.Millisecond,
 		Concurrency:      0,
-		Confirmations:    0,
+		Confirmations:    2,
 		GasMultiplier:    1.0,
 		BatchSize:        20,
 		MaxGas:           500_000_000,
@@ -98,6 +98,11 @@ func (s *SubmitterTestSuite) TestSubmit() {
 	// set the `SCC.nextIndex`
 	s.TSCC.SetNextIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(int64(nextIndex)))
 	s.Hub.Commit()
+
+	// Confirm blocks
+	for i := 0; i < s.submitter.cfg.Confirmations; i++ {
+		s.Hub.Mining()
+	}
 
 	// submitter do the work.
 	s.submitter.stakemanager.Refresh(ctx)
@@ -154,4 +159,136 @@ func (s *SubmitterTestSuite) TestSubmit() {
 			}
 		}
 	}
+}
+
+func (s *SubmitterTestSuite) TestStartSubmit() {
+	ctx, cancel := context.WithCancel(context.Background())
+	batchIndexes := s.Range(0, 5)
+	nextIndex := 2
+	signers := s.StakeManager.Operators
+
+	// Start submitter
+	s.submitter.stakemanager.Refresh(ctx)
+	go s.submitter.startSubmitter(ctx, s.task)
+	// Dry run to cover no signature case
+	// Manually confirmed by checking the logs
+	time.Sleep(s.submitter.cfg.Interval)
+
+	// Confirm the `stake amount shortage` case is covered
+	// Manually confirmed by checking the logs
+	_, event := s.EmitStateBatchAppended(0)
+	s.DB.OPSignature.Save(
+		nil, nil,
+		signers[0],
+		s.SCCAddr,
+		event.BatchIndex.Uint64(),
+		event.BatchRoot,
+		true,
+		database.RandSignature(),
+	)
+	// wait for the submitter to work
+	time.Sleep(s.submitter.cfg.Interval * 2)
+
+	// Confirm succcesfully tx submission case
+	// set the `SCC.nextIndex`
+	s.TSCC.SetNextIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(int64(nextIndex)))
+	s.Hub.Commit()
+	// Confirm blocks
+	for i := 0; i < s.submitter.cfg.Confirmations; i++ {
+		s.Hub.Mining()
+	}
+
+	// save dummy signatures
+	events := make([]*tscc.SccStateBatchAppended, len(batchIndexes))
+	signatures := make([][]*database.OptimismSignature, len(batchIndexes))
+	for i := range batchIndexes {
+		_, events[i] = s.EmitStateBatchAppended(i)
+		signatures[i] = make([]*database.OptimismSignature, len(signers))
+
+		for j := range s.Range(0, len(signers)) {
+			signatures[i][j], _ = s.DB.OPSignature.Save(
+				nil, nil,
+				signers[j],
+				s.SCCAddr,
+				events[i].BatchIndex.Uint64(),
+				events[i].BatchRoot,
+				i < len(batchIndexes)-1,
+				database.RandSignature(),
+			)
+		}
+
+		// no more signatures than the minimum stake should be sent
+		sort.Slice(signatures[i], func(j, h int) bool {
+			// sort by stake amount
+			a := s.submitter.stakemanager.StakeBySigner(signatures[i][j].Signer.Address)
+			b := s.submitter.stakemanager.StakeBySigner(signatures[i][h].Signer.Address)
+			return a.Cmp(b) == 1 // order by desc
+		})
+		signatures[i] = signatures[i][:6]
+		sort.Sort(database.OptimismSignatures(signatures[i]))
+	}
+
+	// submitter do the work.
+	time.Sleep(s.submitter.cfg.Interval * 2)
+	s.Hub.Commit()
+
+	// assert multicall transaction
+	currBlock, _ := s.Hub.Client().BlockByNumber(ctx, nil)
+	mcallTx := currBlock.Transactions()[0]
+	sender, _ := s.Hub.TxSender(mcallTx)
+	s.Equal(s.task.L1Signer().Signer(), sender)
+	s.Equal(s.MulticallAddr, *mcallTx.To())
+
+	mcallReceipt, _ := s.Hub.TransactionReceipt(context.Background(), mcallTx.Hash())
+	s.Len(mcallReceipt.Logs, 6)
+	s.Equal(s.SCCAddr, mcallReceipt.Logs[0].Address)
+	s.Equal(s.SCCVAddr, mcallReceipt.Logs[1].Address)
+	s.Equal(s.SCCAddr, mcallReceipt.Logs[2].Address)
+	s.Equal(s.SCCVAddr, mcallReceipt.Logs[3].Address)
+	s.Equal(s.SCCAddr, mcallReceipt.Logs[4].Address)
+	s.Equal(s.SCCVAddr, mcallReceipt.Logs[5].Address)
+
+	// assert call parameters
+	length, _ := s.TSCCV.SccAssertLogsLen(&bind.CallOpts{Context: ctx})
+	s.Equal(uint64(3), length.Uint64())
+
+	for i := range batchIndexes {
+		if i < nextIndex {
+			got, err := s.TSCCV.AssertLogs(
+				&bind.CallOpts{Context: ctx},
+				big.NewInt(int64(i+nextIndex+1)))
+			s.ErrorContains(err, "execution reverted")
+			s.Equal(common.Address{}, got.StateCommitmentChain)
+		} else {
+			got, err := s.TSCCV.AssertLogs(
+				&bind.CallOpts{Context: ctx},
+				big.NewInt(int64(i-nextIndex)))
+			s.NoError(err)
+			s.Equal(s.SCCAddr, got.StateCommitmentChain)
+			s.Equal(events[i].BatchIndex.Uint64(), got.BatchHeader.BatchIndex.Uint64())
+			s.Equal(events[i].BatchRoot, got.BatchHeader.BatchRoot)
+			s.Equal(events[i].BatchSize.Uint64(), got.BatchHeader.BatchSize.Uint64())
+			s.Equal(events[i].PrevTotalElements.Uint64(), got.BatchHeader.PrevTotalElements.Uint64())
+			s.Equal(events[i].ExtraData, got.BatchHeader.ExtraData)
+			s.Equal(i < len(batchIndexes)-1, got.Approve)
+
+			// no more signatures than the minimum stake should be sent
+			s.Len(got.Signatures, len(signatures[i])*65)
+			for j, sig := range signatures[i] {
+				start := j * 65
+				end := start + 65
+				s.Equal(sig.Signature[:], got.Signatures[start:end])
+			}
+		}
+	}
+
+	// Cancel will exit receipt waiting loop
+	cancel()
+
+	// Confirm old signatures are cleaned up
+	time.Sleep(s.submitter.cfg.Interval)
+	deleteIndex := uint64(1)
+	rows, err := s.DB.OPSignature.Find(nil, nil, &s.SCCAddr, &deleteIndex, 1000, 0)
+	s.NoError(err)
+	s.True(len(rows) == 0)
 }

--- a/submitter/submitter_test.go
+++ b/submitter/submitter_test.go
@@ -161,7 +161,7 @@ func (s *SubmitterTestSuite) TestSubmit() {
 	}
 }
 
-func (s *SubmitterTestSuite) TestStartSubmit() {
+func (s *SubmitterTestSuite) TestStartSubmitter() {
 	ctx, cancel := context.WithCancel(context.Background())
 	batchIndexes := s.Range(0, 5)
 	nextIndex := 2
@@ -169,7 +169,7 @@ func (s *SubmitterTestSuite) TestStartSubmit() {
 
 	// Start submitter
 	s.submitter.stakemanager.Refresh(ctx)
-	go s.submitter.startSubmitter(ctx, s.task)
+	go s.submitter.startSubmitter(ctx, s.task, 0)
 	// Dry run to cover no signature case
 	// Manually confirmed by checking the logs
 	time.Sleep(s.submitter.cfg.Interval)

--- a/submitter/submitter_test.go
+++ b/submitter/submitter_test.go
@@ -168,9 +168,9 @@ func (s *SubmitterTestSuite) TestStartSubmitter() {
 	nextIndex := 2
 	signers := s.StakeManager.Operators
 
-	// Start submitter
+	// Start submitter by adding task
 	s.submitter.stakemanager.Refresh(ctx)
-	go s.submitter.startSubmitter(ctx, s.task, 0)
+	s.submitter.AddTask(ctx, s.task, 0)
 	// Dry run to cover no signature case
 	// Manually confirmed by checking the logs
 	time.Sleep(s.submitter.cfg.Interval)

--- a/submitter/submitter_test.go
+++ b/submitter/submitter_test.go
@@ -229,7 +229,7 @@ func (s *SubmitterTestSuite) TestStartSubmitter() {
 	}
 
 	// submitter do the work.
-	time.Sleep(s.submitter.cfg.Interval * 2)
+	time.Sleep(s.submitter.cfg.Interval * 3)
 	s.Hub.Commit()
 
 	// assert multicall transaction

--- a/submitter/submitter_test.go
+++ b/submitter/submitter_test.go
@@ -106,7 +106,7 @@ func (s *SubmitterTestSuite) TestSubmit() {
 
 	// submitter do the work.
 	s.submitter.stakemanager.Refresh(ctx)
-	go s.submitter.work(ctx, s.task)
+	go s.submitter.work(ctx, s.task, nil)
 	time.Sleep(time.Second / 10)
 	s.Hub.Commit()
 

--- a/testhelper/backend/backend.go
+++ b/testhelper/backend/backend.go
@@ -37,6 +37,10 @@ type Backend struct {
 	*simulated.Backend
 }
 
+func (b *Backend) FilterLogsWithRateThottling(ctx context.Context, q ethereum.FilterQuery) (logs []types.Log, err error) {
+	return b.FilterLogs(ctx, q)
+}
+
 func (b *Backend) NewBatchHeaderClient() (ethutil.BatchHeaderClient, error) {
 	return &BatchHeaderClient{b}, nil
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -175,6 +175,9 @@ func (w *Verifier) work(ctx context.Context, task verse.VerifiableVerse, chainId
 	var logs []types.Log
 	if !skipFetchlog {
 		if logs, err = w.l1Signer.FilterLogsWithRateThottling(ctx, verse.NewEventLogFilter(start, end, []common.Address{task.RollupContract()})); err != nil {
+			if errors.Is(err, ethutil.ErrTooManyRequests) {
+				log.Warn("Rate limit exceeded", "start", start, "end", end, "err", err)
+			}
 			return fmt.Errorf("failed to fetch(start: %d, end: %d) event logs from hub-layer: %w", start, end, err)
 		}
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -268,7 +268,7 @@ func (w *Verifier) work2(ctx context.Context, task verse.VerifiableVerse, chainI
 	// fetch event logs
 	var logs []types.Log
 	if !skipFetchlog {
-		if logs, err = w.l1Signer.FilterLogs(ctx, verse.NewEventLogFilter(start, end)); err != nil {
+		if logs, err = w.l1Signer.FilterLogs(ctx, verse.NewEventLogFilter(start, end, []common.Address{task.RollupContract()})); err != nil {
 			return fmt.Errorf("failed to fetch(start: %d, end: %d) event logs from hub-layer: %w", start, end, err)
 		}
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/oasysgames/oasys-optimism-verifier/config"
+	"github.com/oasysgames/oasys-optimism-verifier/contract/l2oo"
+	"github.com/oasysgames/oasys-optimism-verifier/contract/scc"
 	"github.com/oasysgames/oasys-optimism-verifier/database"
 	"github.com/oasysgames/oasys-optimism-verifier/ethutil"
 	"github.com/oasysgames/oasys-optimism-verifier/util"
@@ -73,6 +77,36 @@ func (w *Verifier) SubscribeNewSignature(ctx context.Context) *SignatureSubscrip
 		ch <- data.(*database.OptimismSignature)
 	})
 	return &SignatureSubscription{Cancel: cancel, ch: ch}
+}
+
+func (w *Verifier) AddVerse(ctx context.Context, v verse.VerifiableVerse, chainId uint64) {
+	go w.startVerifier(ctx, v, chainId)
+}
+
+func (w *Verifier) startVerifier(ctx context.Context, v verse.VerifiableVerse, chainId uint64) {
+	var (
+		tick                     = time.NewTicker(w.cfg.Interval)
+		nextEventFetchStartBlock uint64
+		counter                  int
+		publishAllUnverifiedSigs = func() bool {
+			counter++
+			// Publish all unverified signatures every 4 times.
+			return counter%4 == 0
+		}
+	)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.log.Info("Verifying work stopped", "chainId", chainId)
+			return
+		case <-tick.C:
+			if err := w.work2(ctx, v, chainId, &nextEventFetchStartBlock, publishAllUnverifiedSigs()); err != nil {
+				w.log.Error("Failed to run verification", "err", err)
+			}
+		}
+	}
 }
 
 func (w *Verifier) Work(ctx context.Context) {
@@ -168,6 +202,156 @@ func (w *Verifier) work(ctx context.Context, task verse.VerifiableVerse) {
 		w.topic.Publish(row)
 		log.Info("Verification completed", "approved", approved)
 	}
+}
+
+func (w *Verifier) work2(ctx context.Context, task verse.VerifiableVerse, chainId uint64, nextStart *uint64, publishAllUnverifiedSigs bool) error {
+	// run verification tasks until time out
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, w.cfg.StateCollectTimeout)
+	defer cancel()
+
+	// Assume the fetched nextIndex is not reorged, as we confirm `w.cfg.Confirmations` blocks
+	nextIndex, err := task.NextIndexWithConfirm(&bind.CallOpts{Context: ctx}, uint64(w.cfg.Confirmations), true)
+	if err != nil {
+		return fmt.Errorf("failed to call the NextIndex method: %w", err)
+	}
+	log := log.New("chainId", chainId, "next-index", nextIndex)
+
+	// Clean up old signatures
+	if err := w.cleanOldSignatures(task.RollupContract(), nextIndex.Uint64()); err != nil {
+		log.Warn("Failed to delete old signatures", "err", err)
+	}
+
+	// determine the start block number
+	var (
+		start        uint64
+		skipFetchlog bool
+	)
+	end, err := w.l1Signer.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch the latest block number: %w", err)
+	}
+	if nextStart != nil {
+		start = *nextStart
+		if start > end {
+			// Block number is not updated yet.
+			skipFetchlog = true
+		}
+	} else {
+		// start fetching logs from 7 days ago
+		backLimit := uint64(5760) * 7
+		if end < backLimit {
+			start = 0
+		} else {
+			start = end - backLimit
+		}
+	}
+
+	// Next start block is the current end block + 1
+	*nextStart = end + 1
+
+	if skipFetchlog && !publishAllUnverifiedSigs {
+		return nil
+	}
+
+	// fetch event logs
+	var logs []types.Log
+	if !skipFetchlog {
+		if logs, err = w.l1Signer.FilterLogs(ctx, verse.NewEventLogFilter(start, end)); err != nil {
+			return fmt.Errorf("failed to fetch(start: %d, end: %d) event logs from hub-layer: %w", start, end, err)
+		}
+	}
+
+	// verify the fetched logs
+	opsigs := []*database.OptimismSignature{}
+	for i := range logs {
+		event, err := verse.ParseEventLog(&logs[i])
+		if err != nil {
+			log.Warn("Failed to parse event log", "block", logs[i].BlockNumber, "contract", logs[i].Address.Hex(), "err", err)
+			continue
+		}
+
+		// parse event log
+		rollupEvent, ok := event.(*verse.RollupedEvent)
+		if !ok {
+			// skip `*verse.DeletedEvent` or `*verse.VerifiedEvent`
+			continue
+		}
+		var dbEvent database.OPEvent
+		switch t := rollupEvent.Parsed.(type) {
+		case *scc.SccStateBatchAppended:
+			var model database.OptimismState
+			model.BatchIndex = t.BatchIndex.Uint64()
+			model.PrevTotalElements = t.PrevTotalElements.Uint64()
+			model.BatchSize = t.BatchSize.Uint64()
+			model.BatchRoot = t.BatchRoot
+			dbEvent = &model
+		case *l2oo.OasysL2OutputOracleOutputProposed:
+			var model database.OpstackProposal
+			model.L2OutputIndex = t.L2OutputIndex.Uint64()
+			model.L2BlockNumber = t.L2BlockNumber.Uint64()
+			model.OutputRoot = t.OutputRoot
+			dbEvent = &model
+		default:
+			return fmt.Errorf("unsupported event type: %T", t)
+		}
+
+		if dbEvent.GetRollupIndex() < nextIndex.Uint64() {
+			// skip old events
+			continue
+		}
+
+		approved, err := task.Verify(log, ctx, dbEvent, w.cfg.StateCollectLimit)
+		if err != nil {
+			log.Error("Failed to verification", "err", err, "rollup-index", dbEvent.GetRollupIndex())
+			continue
+		}
+
+		msg := database.NewMessage(dbEvent, w.l1Signer.ChainID(), approved)
+		sig, err := msg.Signature(w.l1Signer.SignData)
+		if err != nil {
+			log.Error("Failed to calculate signature", "err", err, "rollup-index", dbEvent.GetRollupIndex())
+			continue
+		}
+
+		row, err := w.db.OPSignature.Save(
+			nil, nil,
+			w.l1Signer.Signer(),
+			dbEvent.GetContract().Address,
+			dbEvent.GetRollupIndex(),
+			dbEvent.GetRollupHash(),
+			approved,
+			sig)
+		if err != nil {
+			log.Error("Failed to save signature", "err", err, "rollup-index", dbEvent.GetRollupIndex())
+			continue
+		}
+
+		opsigs = append(opsigs, row)
+		log.Debug("Verification completed", "approved", approved, "rollup-index", dbEvent.GetRollupIndex())
+	}
+	if len(opsigs) > 0 {
+		log.Debug("Completed verification of all fetched logs", "count-logs", len(logs), "count-newsigs", len(opsigs))
+	}
+
+	// Will publish all unverified signatures if the flag is set.
+	if publishAllUnverifiedSigs {
+		rows, err := w.db.OPSignature.FindUnverifiedBySigner(w.l1Signer.Signer(), nextIndex.Uint64())
+		if err != nil {
+			log.Error("Failed to find unverified signatures", "err", err)
+		}
+		opsigs = append(opsigs, rows...)
+	}
+
+	// publish each signatures
+	for i := range opsigs {
+		w.topic.Publish(opsigs[i])
+	}
+	if len(opsigs) > 0 {
+		log.Info("Published verified signatures", "count", len(opsigs))
+	}
+
+	return nil
 }
 
 func (w *Verifier) deleteInvalidNextIndexSignature(task verse.VerifiableVerse, nextIndex uint64) {

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -376,7 +376,7 @@ func (w *Verifier) work2(ctx context.Context, task verse.VerifiableVerse, chainI
 		// publish all signatures at once
 		w.p2p.PublishSignatures(ctx, opsigs)
 	} else {
-		log.Info("No signatures to publish")
+		log.Info("No signatures to publish", "count-logs", len(logs), "start", start, "end", end)
 	}
 
 	return nil

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -63,7 +63,6 @@ func (w *Verifier) HasTask(contract common.Address, l2RPC string) bool {
 }
 
 func (w *Verifier) AddTask(ctx context.Context, task verse.VerifiableVerse, chainId uint64) {
-	task.Logger(w.log).Info("Add verifier task")
 	_, exists := w.tasks.Load(task.RollupContract())
 	w.tasks.Store(task.RollupContract(), task)
 	if !exists {
@@ -238,6 +237,7 @@ func (w *Verifier) work(ctx context.Context, task verse.VerifiableVerse, chainId
 	if len(opsigs) > 0 {
 		// publish all signatures at once
 		w.p2p.PublishSignatures(ctx, opsigs)
+		log.Info("Published signatures", "count-logs", len(logs), "count-sigs", len(opsigs), "start", start, "end", end)
 	} else {
 		log.Info("No signatures to publish", "count-logs", len(logs), "start", start, "end", end)
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oasysgames/oasys-optimism-verifier/config"
 	"github.com/oasysgames/oasys-optimism-verifier/database"
 	"github.com/oasysgames/oasys-optimism-verifier/ethutil"
-	"github.com/oasysgames/oasys-optimism-verifier/util"
 	"github.com/oasysgames/oasys-optimism-verifier/verse"
 )
 
@@ -24,10 +23,8 @@ type Verifier struct {
 	db       *database.Database
 	l1Signer ethutil.SignableClient
 	p2p      P2P
-	topic    *util.Topic
 	tasks    sync.Map
 	log      log.Logger
-	wg       *util.WorkerGroup
 	running  *sync.Map
 }
 
@@ -47,9 +44,7 @@ func NewVerifier(
 		db:       db,
 		p2p:      p2p,
 		l1Signer: l1Signer,
-		topic:    util.NewTopic(),
 		log:      log.New("worker", "verifier"),
-		wg:       util.NewWorkerGroup(cfg.Concurrency),
 		running:  &sync.Map{},
 	}
 }
@@ -70,23 +65,11 @@ func (w *Verifier) HasTask(contract common.Address, l2RPC string) bool {
 func (w *Verifier) AddTask(ctx context.Context, task verse.VerifiableVerse, chainId uint64) {
 	task.Logger(w.log).Info("Add verifier task")
 	w.tasks.Store(task.RollupContract(), task)
-	w.AddVerse(ctx, task, chainId)
+	go w.startVerifier(ctx, task, chainId)
 }
 
 func (w *Verifier) RemoveTask(contract common.Address) {
 	w.tasks.Delete(contract)
-}
-
-func (w *Verifier) SubscribeNewSignature(ctx context.Context) *SignatureSubscription {
-	ch := make(chan *database.OptimismSignature)
-	cancel := w.topic.Subscribe(ctx, func(ctx context.Context, data interface{}) {
-		ch <- data.(*database.OptimismSignature)
-	})
-	return &SignatureSubscription{Cancel: cancel, ch: ch}
-}
-
-func (w *Verifier) AddVerse(ctx context.Context, v verse.VerifiableVerse, chainId uint64) {
-	go w.startVerifier(ctx, v, chainId)
 }
 
 func (w *Verifier) startVerifier(ctx context.Context, v verse.VerifiableVerse, chainId uint64) {
@@ -108,109 +91,14 @@ func (w *Verifier) startVerifier(ctx context.Context, v verse.VerifiableVerse, c
 			w.log.Info("Verifying work stopped", "chainId", chainId)
 			return
 		case <-tick.C:
-			if err := w.work2(ctx, v, chainId, &nextEventFetchStartBlock, publishAllUnverifiedSigs()); err != nil {
+			if err := w.work(ctx, v, chainId, &nextEventFetchStartBlock, publishAllUnverifiedSigs()); err != nil {
 				w.log.Error("Failed to run verification", "err", err)
 			}
 		}
 	}
 }
 
-func (w *Verifier) Work(ctx context.Context) {
-	w.tasks.Range(func(key, val interface{}) bool {
-		workerID := key.(common.Address).Hex()
-		task := val.(verse.VerifiableVerse)
-
-		// deduplication
-		if _, ok := w.running.Load(workerID); ok {
-			return true
-		}
-		w.running.Store(workerID, 1)
-
-		if !w.wg.Has(workerID) {
-			worker := func(ctx context.Context, rname string, data interface{}) {
-				defer w.running.Delete(rname)
-				w.work(ctx, data.(verse.VerifiableVerse))
-			}
-			w.wg.AddWorker(ctx, workerID, worker)
-		}
-
-		w.wg.Enqueue(workerID, task)
-		return true
-	})
-}
-
-func (w *Verifier) work(ctx context.Context, task verse.VerifiableVerse) {
-	log := task.Logger(w.log)
-
-	// Assume the fetched nextIndex is not reorged, as we confirm `w.cfg.Confirmations` blocks
-	nextIndex, err := task.NextIndexWithConfirm(&bind.CallOpts{Context: ctx}, uint64(w.cfg.Confirmations), true)
-	if err != nil {
-		log.Error("Failed to call the NextIndex method", "err", err)
-		return
-	}
-	log = log.New("next-index", nextIndex)
-
-	// Clean up old signatures
-	if err := w.cleanOldSignatures(task.RollupContract(), nextIndex.Uint64()); err != nil {
-		w.log.Warn("Failed to delete old signatures", "nextIndex", nextIndex, "err", err)
-	}
-
-	// verify the signature that match the nextIndex
-	// and delete after signatures if there is a problem.
-	// Prevent getting stuck indefinitely in the Verify waiting
-	// event due to a bug in the signature creation process.
-	w.deleteInvalidNextIndexSignature(task, nextIndex.Uint64())
-
-	// run verification tasks until time out
-	ctx, cancel := context.WithTimeout(ctx, w.cfg.StateCollectTimeout)
-	defer cancel()
-
-	for rollupIndex := nextIndex.Uint64(); ; rollupIndex++ {
-		events, err := task.EventDB().FindForVerification(
-			w.l1Signer.Signer(), task.RollupContract(), rollupIndex, 1)
-		if err != nil {
-			log.Error("Failed to find rollup events", "err", err)
-			return
-		} else if len(events) == 0 {
-			log.Debug("Wait for new rollup event")
-			return
-		}
-
-		log := log.New("rollup-index", events[0].GetRollupIndex())
-		log.Info("Start verification")
-
-		approved, err := task.Verify(log, ctx, events[0], w.cfg.StateCollectLimit)
-		if err != nil {
-			log.Error("Failed to verification", "err", err)
-			return
-		}
-
-		msg := database.NewMessage(events[0], w.l1Signer.ChainID(), approved)
-		sig, err := msg.Signature(w.l1Signer.SignData)
-		if err != nil {
-			log.Error("Failed to calculate signature", "err", err)
-			return
-		}
-
-		row, err := w.db.OPSignature.Save(
-			nil, nil,
-			w.l1Signer.Signer(),
-			events[0].GetContract().Address,
-			events[0].GetRollupIndex(),
-			events[0].GetRollupHash(),
-			approved,
-			sig)
-		if err != nil {
-			log.Error("Failed to save signature", "err", err)
-			return
-		}
-
-		w.topic.Publish(row)
-		log.Info("Verification completed", "approved", approved)
-	}
-}
-
-func (w *Verifier) work2(ctx context.Context, task verse.VerifiableVerse, chainId uint64, nextStart *uint64, publishAllUnverifiedSigs bool) error {
+func (w *Verifier) work(ctx context.Context, task verse.VerifiableVerse, chainId uint64, nextStart *uint64, publishAllUnverifiedSigs bool) error {
 	// run verification tasks until time out
 	var (
 		cancel    context.CancelFunc
@@ -392,52 +280,6 @@ func (w *Verifier) verifyAndSaveLog(ctx context.Context, log *types.Log, task ve
 	return row, nil
 }
 
-func (w *Verifier) deleteInvalidNextIndexSignature(task verse.VerifiableVerse, nextIndex uint64) {
-	log := task.Logger(w.log).New("next-index", nextIndex)
-
-	signer := w.l1Signer.Signer()
-	contract := task.RollupContract()
-	sigs, err := w.db.OPSignature.Find(nil, &signer, &contract, &nextIndex, 1, 0)
-	if err != nil {
-		log.Error("Unable to find signatures", "err", err)
-		return
-	} else if len(sigs) == 0 {
-		log.Debug("No invalid signature")
-		return
-	}
-
-	event, err := task.EventDB().FindByRollupIndex(contract, nextIndex)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			log.Debug("No rollup event")
-		} else {
-			log.Error("Unable to find rollup event", "err", err)
-		}
-		return
-	}
-
-	err = database.NewMessage(event, w.l1Signer.ChainID(), true).
-		VerifySigner(sigs[0].Signature[:], signer)
-	if _, ok := err.(*ethutil.SignerMismatchError); ok {
-		// possible reject signature
-		err = database.NewMessage(event, w.l1Signer.ChainID(), false).
-			VerifySigner(sigs[0].Signature[:], signer)
-	}
-	if err == nil {
-		log.Debug("No invalid signature")
-		return
-	}
-
-	log.Warn("Found invalid signature", "signature", sigs[0].Signature.Hex())
-
-	rows, err := w.db.OPSignature.Deletes(signer, contract, nextIndex)
-	if err != nil {
-		log.Error("Failed to delete invalid signatures", "err", err)
-	} else {
-		log.Warn("Deleted invalid signatures", "rows", rows)
-	}
-}
-
 func (w *Verifier) cleanOldSignatures(contract common.Address, nextIndex uint64) error {
 	var verifiedIndex uint64
 	if nextIndex == 0 {
@@ -455,13 +297,4 @@ func (w *Verifier) cleanOldSignatures(contract common.Address, nextIndex uint64)
 		return fmt.Errorf("failed to delete old signatures. deleteIndex: %d, : %w", deleteIndex, err)
 	}
 	return nil
-}
-
-type SignatureSubscription struct {
-	Cancel context.CancelFunc
-	ch     chan *database.OptimismSignature
-}
-
-func (s *SignatureSubscription) Next() <-chan *database.OptimismSignature {
-	return s.ch
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -55,10 +55,10 @@ func (s *VerifierTestSuite) SetupTest() {
 }
 
 func (s *VerifierTestSuite) TestStartVerifier() {
-	// start verifier
+	// start verifier by adding task
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go s.verifier.startVerifier(ctx, s.task, 0)
+	s.verifier.AddTask(ctx, s.task, 0)
 
 	batches := s.Range(0, 3)
 	batchSize := 5

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -54,7 +54,7 @@ func (s *VerifierTestSuite) SetupTest() {
 	}, s.DB, &MockP2P{sigsCh: s.sigsCh}, s.SignableHub)
 
 	s.task = verse.NewOPLegacy(s.DB, s.Hub, s.SCCAddr).WithVerifiable(s.Verse)
-	s.verifier.AddTask(s.task)
+	s.verifier.AddTask(context.Background(), s.task, 0)
 }
 
 func (s *VerifierTestSuite) TestVerify() {
@@ -281,9 +281,12 @@ func (s *VerifierTestSuite) TestStartVerifier() {
 	s.Hub.Commit()
 
 	// no prior signature than verified index should be sent
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		sigs = <-s.sigsCh
-		s.Len(sigs, 2)
+		if len(sigs) == len(batches) {
+			// signatures before incrementing `nextIndex` are remained
+			continue
+		}
 		for _, sig := range sigs {
 			s.True(sig.RollupIndex >= uint64(nextIndex))
 		}

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/oasysgames/oasys-optimism-verifier/config"
-	"github.com/oasysgames/oasys-optimism-verifier/contract/scc"
 	"github.com/oasysgames/oasys-optimism-verifier/database"
-	"github.com/oasysgames/oasys-optimism-verifier/util"
 	"github.com/oasysgames/oasys-optimism-verifier/verse"
 	"github.com/stretchr/testify/suite"
 
@@ -24,7 +22,6 @@ type VerifierTestSuite struct {
 
 	verifier *Verifier
 	task     verse.VerifiableVerse
-	stopWork context.CancelFunc
 	sigsCh   chan []*database.OptimismSignature
 }
 
@@ -55,171 +52,6 @@ func (s *VerifierTestSuite) SetupTest() {
 
 	s.task = verse.NewOPLegacy(s.DB, s.Hub, s.SCCAddr).WithVerifiable(s.Verse)
 	s.verifier.AddTask(context.Background(), s.task, 0)
-}
-
-func (s *VerifierTestSuite) TestVerify() {
-	cases := []struct {
-		batchRoot     string
-		wantSignature string
-		wantApproved  bool
-	}{
-		{
-			"0x9ad778e5c9936769419b31119fb0bbc9d7b66c88ee10f0986ce46a6d302792b7",
-			"0xa01df213459635dcd05e84b1828ba26b9469d52bf2860698437ac466d0e9afba5bda3efa378d9c36ca9eb7f4ce87f2aad73deeea357d7dba141d3469d095bb8c1c",
-			true,
-		},
-		{
-			"0x3b6af01f7666ff6990d8ccaa995f6efdae442ad24b5a354a70029ed8a2713357",
-			"0x21c90d613eb6a8fbb43d858de6c6aa8c569e0c04e0e26af73f0a1043e533f26631e76beda58d5084bd93a5159a25cd6c80d5396916d1247644e63422e7cef85c1c",
-			false,
-		},
-	}
-
-	batchSize := 10
-
-	s.startWorker()
-	defer s.stopWork()
-
-	// send transactions to verse-layer
-	s.sendVerseTransactions(10 * len(cases))
-
-	// emit and collect `StateBatchAppended` events
-	for batchIndex, tt := range cases {
-		_, err := s.task.EventDB().Save(
-			s.task.RollupContract(),
-			&scc.SccStateBatchAppended{
-				BatchIndex:        big.NewInt(int64(batchIndex)),
-				BatchRoot:         util.BytesToBytes32(common.FromHex(tt.batchRoot)),
-				BatchSize:         big.NewInt(int64(batchSize)),
-				PrevTotalElements: big.NewInt(int64(batchSize * batchIndex)),
-				ExtraData:         []byte(fmt.Sprintf("test-%d", batchSize))})
-		s.NoError(err)
-	}
-
-	// subscribe new signature
-	subscribes := s.waitPublished(len(cases))
-
-	// assert
-	for batchIndex, tt := range cases {
-		bi64 := uint64(batchIndex)
-		got0, _ := s.DB.OPSignature.Find(nil, nil, nil, &bi64, 1, 0)
-		got1 := subscribes[batchIndex]
-
-		s.Equal(tt.batchRoot, got0[0].RollupHash.Hex())
-		s.Equal(tt.batchRoot, got1.RollupHash.Hex())
-
-		s.Equal(tt.wantApproved, got0[0].Approved)
-		s.Equal(tt.wantApproved, got1.Approved)
-
-		s.Equal(tt.wantSignature, got0[0].Signature.Hex())
-		s.Equal(tt.wantSignature, got1.Signature.Hex())
-	}
-}
-
-func (s *VerifierTestSuite) TestDeleteInvalidSignature() {
-	s.startWorker()
-	defer s.stopWork()
-
-	batches := s.Range(0, 10)
-	batchSize := 5
-	invalidBatch := 6
-
-	// send transactions to verse-layer
-	merkleRoots := make([][32]byte, len(batches))
-	for batchIdx := range batches {
-		elements := make([][32]byte, batchSize)
-		for i, header := range s.sendVerseTransactions(batchSize) {
-			elements[i] = header.Root
-		}
-		if merkleRoot, err := verse.CalcMerkleRoot(elements); s.NoError(err) {
-			merkleRoots[batchIdx] = merkleRoot
-		}
-	}
-
-	createds := make([]*database.OptimismSignature, len(batches))
-	for batchIdx, merkleRoot := range merkleRoots {
-		// save verify waiting state
-		_, err := s.task.EventDB().Save(
-			s.task.RollupContract(),
-			&scc.SccStateBatchAppended{
-				BatchIndex:        big.NewInt(int64(batchIdx)),
-				BatchRoot:         merkleRoot,
-				BatchSize:         big.NewInt(int64(batchSize)),
-				PrevTotalElements: big.NewInt(int64(batchIdx * batchSize)),
-				ExtraData:         []byte(fmt.Sprintf("test-%d", batchIdx))})
-		s.NoError(err)
-
-		// run verification
-		sigs := s.waitPublished(1)
-		s.Len(sigs, 1)
-		s.Equal(merkleRoot[:], sigs[0].RollupHash[:])
-		createds[batchIdx] = sigs[0]
-	}
-
-	// increment `nextIndex`
-	for batchIdx := range s.Range(0, invalidBatch) {
-		s.TSCC.EmitStateBatchVerified(
-			s.SignableHub.TransactOpts(context.Background()),
-			big.NewInt(int64(batchIdx)),
-			merkleRoots[batchIdx],
-		)
-		s.SignableHub.Commit()
-	}
-	// Confirm blocks
-	for i := 0; i < s.verifier.cfg.Confirmations; i++ {
-		s.Hub.Mining()
-	}
-
-	// run `deleteInvalidSignature`, but nothing happens
-	s.Len(s.waitPublished(1), 0)
-
-	signer := s.SignableHub.Signer()
-	contract := s.task.RollupContract()
-	gots, _ := s.DB.OPSignature.Find(nil, &signer, &contract, nil, 100, 0)
-	// Make sure more than 3 depth older signature is cleaned up
-	deletedBatches := invalidBatch - 3
-	s.Equal(len(batches)-deletedBatches, len(gots))
-
-	for batchIdx := range batches {
-		if batchIdx < deletedBatches {
-			continue
-		}
-		i := batchIdx - deletedBatches
-		// should not be re-created
-		s.Equal(createds[batchIdx].ID, gots[i].ID)
-		s.Equal(createds[batchIdx].Signature, gots[i].Signature)
-	}
-
-	// update to invalid signature
-	s.DB.OPSignature.Save(
-		&createds[invalidBatch].ID,
-		&createds[invalidBatch].PreviousID,
-		createds[invalidBatch].Signer.Address,
-		createds[invalidBatch].Contract.Address,
-		createds[invalidBatch].RollupIndex,
-		createds[invalidBatch].RollupHash,
-		createds[invalidBatch].Approved,
-		database.RandSignature())
-
-	// run `deleteInvalidSignature`
-	s.Len(s.waitPublished(len(batches)-invalidBatch), len(batches)-invalidBatch)
-
-	gots, _ = s.DB.OPSignature.Find(nil, &signer, &contract, nil, 100, 0)
-	s.Equal(len(batches)-deletedBatches, len(gots))
-
-	for batchIdx := range batches {
-		if batchIdx < deletedBatches {
-			continue
-		}
-		i := batchIdx - deletedBatches
-		if batchIdx < invalidBatch {
-			s.Equal(createds[batchIdx].ID, gots[i].ID)
-		} else {
-			// should be re-created
-			s.NotEqual(createds[batchIdx].ID, gots[i].ID)
-		}
-		s.Equal(createds[batchIdx].Signature, gots[i].Signature)
-	}
 }
 
 func (s *VerifierTestSuite) TestStartVerifier() {
@@ -318,51 +150,4 @@ func (s *VerifierTestSuite) sendVerseTransactions(count int) (headers []*types.H
 		headers = append(headers, h)
 	}
 	return headers
-}
-
-func (s *VerifierTestSuite) startWorker() {
-	ctx := context.Background()
-	ctx, s.stopWork = context.WithCancel(ctx)
-
-	go func() {
-		tick := time.NewTicker(s.verifier.cfg.Interval)
-		defer tick.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-tick.C:
-				s.verifier.Work(ctx)
-			}
-		}
-	}()
-}
-
-func (s *VerifierTestSuite) waitPublished(count int) []*database.OptimismSignature {
-	ctx, candel := context.WithTimeout(context.Background(), time.Second/2)
-	defer candel()
-
-	sub := s.verifier.SubscribeNewSignature(ctx)
-	defer sub.Cancel()
-
-	var published []*database.OptimismSignature
-	go func() {
-		defer candel()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case sig := <-sub.Next():
-				published = append(published, sig)
-				if len(published) == count {
-					return
-				}
-			}
-		}
-	}()
-
-	<-ctx.Done()
-	return published
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -50,6 +50,7 @@ func (s *VerifierTestSuite) SetupTest() {
 		StateCollectLimit:   3,
 		StateCollectTimeout: time.Second,
 		Confirmations:       2,
+		StartBlockOffset:    100,
 	}, s.DB, &MockP2P{sigsCh: s.sigsCh}, s.SignableHub)
 
 	s.task = verse.NewOPLegacy(s.DB, s.Hub, s.SCCAddr).WithVerifiable(s.Verse)

--- a/verse/event_log.go
+++ b/verse/event_log.go
@@ -195,3 +195,22 @@ LOOP:
 		Parsed:   rawEvent,
 	}), nil
 }
+
+func (e *RollupedEvent) CastToDatabaseOPEvent(contract *database.OptimismContract) (dbEvent database.OPEvent, err error) {
+	if e.Parsed == nil {
+		return nil, fmt.Errorf("parsed event is nil, event: %v", e)
+	}
+	switch t := e.Parsed.(type) {
+	case *scc.SccStateBatchAppended:
+		var model database.OptimismState
+		err = model.AssignEvent(contract, e.Parsed)
+		dbEvent = &model
+	case *l2oo.OasysL2OutputOracleOutputProposed:
+		var model database.OpstackProposal
+		err = model.AssignEvent(contract, e.Parsed)
+		dbEvent = &model
+	default:
+		err = fmt.Errorf("unsupported event type: %T", t)
+	}
+	return
+}

--- a/verse/event_log.go
+++ b/verse/event_log.go
@@ -136,11 +136,14 @@ func init() {
 	}
 }
 
-func NewEventLogFilter(fromBlock, toBlock uint64) ethereum.FilterQuery {
+func NewEventLogFilter(fromBlock, toBlock uint64, addresss []common.Address) ethereum.FilterQuery {
 	query := ethereum.FilterQuery{
 		Topics:    [][]common.Hash{make([]common.Hash, len(eventTopics))},
 		FromBlock: new(big.Int).SetUint64(fromBlock),
 		ToBlock:   new(big.Int).SetUint64(toBlock),
+	}
+	if len(addresss) != 0 {
+		query.Addresses = addresss
 	}
 	copy(query.Topics[0], eventTopics)
 	return query

--- a/verse/event_log_test.go
+++ b/verse/event_log_test.go
@@ -52,7 +52,7 @@ func (s *EventLogTestSuite) TestNewEventLogFilter() {
 		wants[i] = receipt.Logs[0]
 	}
 
-	gots, _ := s.Hub.FilterLogs(context.Background(), NewEventLogFilter(0, 100))
+	gots, _ := s.Hub.FilterLogs(context.Background(), NewEventLogFilter(0, 100, nil))
 	s.Len(gots, len(wants))
 	for i, want := range wants {
 		s.Equal(*want, gots[i])

--- a/verse/oplegacy.go
+++ b/verse/oplegacy.go
@@ -132,7 +132,7 @@ func (op *verifiableOPLegacy) Verify(
 		}
 	}
 
-	log.Info("Collected L2 states", "elapsed", time.Since(st))
+	log.Debug("Collected L2 states", "elapsed", time.Since(st))
 
 	// calc and compare state root
 	merkleRoot, err := CalcMerkleRoot(elements)

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	Major = 1
-	Minor = 1
+	Minor = 2
 	Patch = 0
 	Meta  = ""
 )


### PR DESCRIPTION
## Changes
- Verifier/Submitterで古い署名を削除する機能をいれた 
- Validator
  - 都度コントラクトのEventをFetch。nextIndex以上の署名をPublishする形に変更。
  - PubSubのSubscribeを停止。受け取っても仕方ないから。
    - 署名を受け取ってP2Pで同期するのをやめた。自分の署名しかPublishしない（上の処理）
  -  Block/Event Collectorを廃止
- Submitter
  - P2P NodeがPublishされた署名を受けとったときに、Streamを開いて同期するのを止めた。ただ、受け取った署名を保存するだけ
-  protoをformat
