### PR TITLE
Improved performance using worker pools

### DIFF
--- a/cmd/config_loader_test.go
+++ b/cmd/config_loader_test.go
@@ -335,6 +335,7 @@ func (s *ConfigLoaderTestSuite) configWithMinCliArgs() *config.Config {
 		Verifier: config.Verifier{
 			Enable:                false,
 			Wallet:                "",
+			MaxWorkers:            defaults["verifier.max_workers"].(int),
 			Interval:              defaults["verifier.interval"].(time.Duration),
 			StateCollectLimit:     defaults["verifier.state_collect_limit"].(int),
 			StateCollectTimeout:   defaults["verifier.state_collect_timeout"].(time.Duration),
@@ -347,7 +348,7 @@ func (s *ConfigLoaderTestSuite) configWithMinCliArgs() *config.Config {
 		Submitter: config.Submitter{
 			Enable:              false,
 			Confirmations:       defaults["submitter.confirmations"].(int),
-			Concurrency:         defaults["submitter.concurrency"].(int),
+			MaxWorkers:          defaults["submitter.max_workers"].(int),
 			Interval:            defaults["submitter.interval"].(time.Duration),
 			GasMultiplier:       defaults["submitter.gas_multiplier"].(float64),
 			BatchSize:           defaults["submitter.batch_size"].(int),

--- a/cmd/config_loader_test.go
+++ b/cmd/config_loader_test.go
@@ -244,8 +244,9 @@ func (s *ConfigLoaderTestSuite) configWithMinCliArgs() *config.Config {
 		Keystore:  s.keystoreDir,
 		Wallets:   map[string]*config.Wallet{},
 		HubLayer: config.HubLayer{
-			ChainID: 1,
-			RPC:     "https://rpc.hub.example.com/",
+			ChainID:   1,
+			RPC:       "https://rpc.hub.example.com/",
+			BlockTime: time.Second * 6,
 		},
 		VerseLayer: config.VerseLayer{
 			Discovery: struct {

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ func init() {
 
 func Defaults() map[string]interface{} {
 	return map[string]interface{}{
+		"hub_layer.block_time": time.Second * 6,
+
 		"verse_layer.discovery.refresh_interval": time.Hour,
 
 		"p2p.no_announce": []string{
@@ -240,6 +242,9 @@ type HubLayer struct {
 
 	// RPC of the Hub-Layer(HTTP or WebSocket).
 	RPC string `validate:"url"`
+
+	// Block interval of the Hub-Layer.
+	BlockTime time.Duration `koanf:"block_time"`
 }
 
 type Verse struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 	hub_layer:
 		chain_id: 12345
 		rpc: http://127.0.0.1:8545/
+		block_time: 1m
 
 	verse_layer:
 		discovery:
@@ -136,8 +137,9 @@ func (s *ConfigTestSuite) TestNewConfig() {
 			},
 		},
 		HubLayer: HubLayer{
-			ChainID: 12345,
-			RPC:     "http://127.0.0.1:8545/",
+			ChainID:   12345,
+			RPC:       "http://127.0.0.1:8545/",
+			BlockTime: time.Minute,
 		},
 		VerseLayer: VerseLayer{
 			Discovery: struct {
@@ -375,6 +377,8 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 
 	got, err := NewConfig(s.toBytes(input), false)
 	s.NoError(err)
+
+	s.Equal(time.Second*6, got.HubLayer.BlockTime)
 
 	s.Equal(time.Hour, got.VerseLayer.Discovery.RefreshInterval)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,6 +74,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 	verifier:
 		enable: true
 		wallet: wallet1
+		max_workers: 50
 		interval: 5s
 		state_collect_limit: 5
 		state_collect_timeout: 1s
@@ -85,8 +86,8 @@ func (s *ConfigTestSuite) TestNewConfig() {
 
 	submitter:
 		enable: true
+		max_workers: 50
 		interval: 5s
-		concurrency: 10
 		confirmations: 4
 		gas_multiplier: 1.5
 		batch_size: 100
@@ -236,6 +237,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 		Verifier: Verifier{
 			Enable:                true,
 			Wallet:                "wallet1",
+			MaxWorkers:            50,
 			Interval:              5 * time.Second,
 			StateCollectLimit:     5,
 			StateCollectTimeout:   time.Second,
@@ -247,7 +249,7 @@ func (s *ConfigTestSuite) TestNewConfig() {
 		},
 		Submitter: Submitter{
 			Enable:              true,
-			Concurrency:         10,
+			MaxWorkers:          50,
 			Interval:            5 * time.Second,
 			Confirmations:       4,
 			GasMultiplier:       1.5,
@@ -409,6 +411,7 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 
 	s.Equal("oasvlfy", got.IPC.Sockname)
 
+	s.Equal(10, got.Verifier.MaxWorkers)
 	s.Equal(6*time.Second, got.Verifier.Interval)
 	s.Equal(1000, got.Verifier.StateCollectLimit)
 	s.Equal(15*time.Second, got.Verifier.StateCollectTimeout)
@@ -418,8 +421,8 @@ func (s *ConfigTestSuite) TestDefaultValues() {
 	s.Equal(time.Minute*5, got.Verifier.MaxRetryBackoff)
 	s.Equal(time.Hour, got.Verifier.RetryTimeout)
 
+	s.Equal(5, got.Submitter.MaxWorkers)
 	s.Equal(30*time.Second, got.Submitter.Interval)
-	s.Equal(50, got.Submitter.Concurrency)
 	s.Equal(3, got.Submitter.Confirmations)
 	s.Equal(1.1, got.Submitter.GasMultiplier)
 	s.Equal(20, got.Submitter.BatchSize)

--- a/ethutil/client.go
+++ b/ethutil/client.go
@@ -32,6 +32,7 @@ type Client interface {
 	bind.ContractBackend
 	bind.DeployBackend
 
+	Close()
 	URL() string
 	BlockNumber(ctx context.Context) (uint64, error)
 	HeaderWithCache(ctx context.Context) (*types.Header, error)
@@ -74,7 +75,6 @@ func NewClient(url string, blockTime time.Duration) (Client, error) {
 
 	// This is magic number, it should be updated based on the network.
 	// semaphore is used for log filtering rate thottling for now.
-	// ethclient.NewClient(c).SendTransaction
 	const concurrency = 2
 	return &client{
 		Client:    ethclient.NewClient(c),
@@ -83,6 +83,10 @@ func NewClient(url string, blockTime time.Duration) (Client, error) {
 		rpc:       c,
 		sem:       semaphore.NewWeighted(concurrency),
 	}, nil
+}
+
+func (c *client) Close() {
+	c.rpc.Close()
 }
 
 func (c *client) URL() string {

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -25,6 +24,11 @@ import (
 const (
 	maxTxSize = 120 * 1024 // 120KB ()
 	minTxGas  = 24871      // Multicall minimum gas
+
+	// Parameters for worker pool.
+	maxIdleWorkerDuration      = time.Minute
+	workerReleaseCheckInterval = time.Second
+	workerReleaseCheckTimeout  = time.Duration(0) // no timeout
 )
 
 var (
@@ -33,114 +37,151 @@ var (
 )
 
 type Submitter struct {
+	// fields passed during construction
 	cfg          *config.Submitter
 	db           *database.Database
+	l1SignerFn   L1SignerFn
 	stakemanager *stakemanager.Cache
-	tasks        sync.Map
+	versepool    verse.VersePool
 	log          log.Logger
+
+	// internal fields
+	tasks util.SyncMap[common.Address, *taskT]
+}
+
+type L1SignerFn func(chainID uint64) ethutil.SignableClient
+
+type taskT struct {
+	verse         verse.TransactableVerse
+	verifiedIndex *uint64
 }
 
 func NewSubmitter(
 	cfg *config.Submitter,
 	db *database.Database,
+	l1SignerFn L1SignerFn,
 	stakemanager *stakemanager.Cache,
+	versepool verse.VersePool,
 ) *Submitter {
 	return &Submitter{
 		cfg:          cfg,
 		db:           db,
+		l1SignerFn:   l1SignerFn,
 		stakemanager: stakemanager,
+		versepool:    versepool,
 		log:          log.New("worker", "submitter"),
 	}
 }
 
-// Deprecated:
 func (w *Submitter) Start(ctx context.Context) {
-	w.log.Info("Submitter started",
-		"interval", w.cfg.Interval,
-		"concurrency", w.cfg.Concurrency,
-		"confirmations", w.cfg.Confirmations,
-		"gas-multiplier", w.cfg.GasMultiplier,
-		"batch-size", w.cfg.BatchSize,
-		"max-gas", w.cfg.MaxGas,
-		"scc-verifier", w.cfg.SCCVerifierAddress,
-		"l2oo-verifier", w.cfg.L2OOVerifierAddress,
-		"use-multicall", w.cfg.UseMulticall,
-		"multicall", w.cfg.MulticallAddress)
-	w.workLoop(ctx)
-}
+	w.log.Info("Submitter started", "config", w.cfg)
 
-func (w *Submitter) startSubmitter(ctx context.Context, contract common.Address, chainId uint64) {
-	var (
-		tick          = time.NewTicker(w.cfg.Interval)
-		duration      = w.cfg.Interval
-		verifiedIndex *uint64
-		resetDuration = func(target time.Duration) {
-			if duration == target {
-				return
-			}
-			duration = target
-			tick.Reset(duration)
-		}
-	)
+	// Create woker pool.
+	wp := util.NewWorkerPool(w.log, w.work, w.cfg.MaxWorkers,
+		maxIdleWorkerDuration, workerReleaseCheckInterval, workerReleaseCheckTimeout)
+	wp.Start()
+	defer wp.Stop()
+
+	// Manage running tasks to prevent dups.
+	var running util.SyncMap[common.Address, time.Time]
+
+	tick := time.NewTicker(w.cfg.Interval)
 	defer tick.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			w.log.Info("Submitting work stopped", "chainId", chainId)
+			log.Info("Submitter stopped")
 			return
 		case <-tick.C:
-			v, found := w.GetTask(contract)
-			if !found {
-				w.log.Info("Exit submitter loop as the task is evicted", "chainId", chainId)
-				return
-			}
-			nextIndex, err := w.work(ctx, v, verifiedIndex)
-			if errors.Is(err, verse.ErrNotSufficientConfirmations) {
-				w.log.Info("Not enough confirmations", "nextIndex", nextIndex, "chainId", chainId)
-				continue
-			} else if errors.Is(err, ErrNoSignatures) {
-				w.log.Info("No signatures to submit", "nextIndex", nextIndex, "chainId", chainId)
-				// Reset the ticker to the original interval
-				resetDuration(w.cfg.Interval)
-				continue
-			} else if errors.Is(err, &StakeAmountShortage{}) {
-				// Wait until enough signatures are collected
-				var (
-					shortageErr      *StakeAmountShortage
-					required, actual *big.Int
-				)
-				if errors.As(err, &shortageErr) {
-					required, actual = fromWei(shortageErr.required), fromWei(shortageErr.actual)
+			w.versepool.Range(func(item *verse.VersePoolItem) bool {
+				if !item.CanSubmit() {
+					return true
 				}
-				w.log.Info("Waiting for enough signatures(stake amount shortage)",
-					"nextIndex", nextIndex, "chainId", chainId, "required", required, "actual", actual)
-				// Reset the ticker to shorten the interval to be able to submit verify tx without waiting for the next interval
-				resetDuration(w.cfg.Interval / 10)
-				continue
-			} else if err == nil {
-				// Finally, succeeded to verify the corresponding rollup index, So move to the next index
-				verifiedIndex = &nextIndex
-				w.log.Info("Successfully verified the rollup index", "verifiedIndex", *verifiedIndex, "chainId", chainId)
-				// Clean up old signatures
-				if err := w.cleanOldSignatures(v.RollupContract(), *verifiedIndex); err != nil {
-					w.log.Warn("Failed to delete old signatures", "verifiedIndex", *verifiedIndex, "chainId", chainId, "err", err)
+
+				log := w.log.New("chain-id", item.Verse().ChainID())
+
+				// Task has internal state and should be cached
+				cacheKey := item.Verse().RollupContract()
+
+				// Skip if previous task is running
+				if started, isRunning := running.Load(cacheKey); isRunning {
+					log.Info("Skip", "elapsed", time.Since(started))
+					return true
 				}
-				// Reset the ticker to the original interval
-				resetDuration(w.cfg.Interval)
-				continue
-			} else if errors.Is(err, ErrAlreadyVerified) {
-				// Skip if the nextIndex is already verified
-				w.log.Info("Already verified the rollup index", "nextIndex", nextIndex, "chainId", chainId)
-				continue
-			} else {
-				w.log.Error("Failed to verify the rollup index", "nextIndex", nextIndex, "chainId", chainId, "err", err)
-			}
+				running.Store(cacheKey, time.Now())
+
+				// Since worker run asynchronously, should not call `running.Delete()` here.
+				release := func() { running.Delete(cacheKey) }
+
+				// If the cache does not exist, create a new task.
+				var task *taskT
+				if cache, ok := w.tasks.Load(cacheKey); ok {
+					task = cache
+				} else {
+					l1Signer := w.l1SignerFn(item.Verse().ChainID())
+					if l1Signer == nil {
+						log.Error("Submitter wallet was not found")
+					} else {
+						task = &taskT{
+							verse: item.Verse().WithTransactable(
+								l1Signer, item.Verse().VerifyContract()),
+							verifiedIndex: nil, // initial value should be nil
+						}
+						w.tasks.Store(cacheKey, task)
+					}
+				}
+
+				if task != nil {
+					wp.Work(ctx, task, func(context.Context, *taskT) { release() })
+				} else {
+					release()
+				}
+				return true
+			})
 		}
 	}
 }
 
-func (w *Submitter) cleanOldSignatures(contract common.Address, verifiedIndex uint64) error {
+func (w *Submitter) work(ctx context.Context, task *taskT) {
+	nextIndex, err := w.submit(ctx, task)
+
+	log := task.verse.Logger(w.log).New("next-index", nextIndex)
+	if task.verifiedIndex != nil {
+		log = log.New("verified-index", *task.verifiedIndex)
+	}
+
+	if errors.Is(err, verse.ErrNotSufficientConfirmations) {
+		log.Info("Not enough confirmations")
+	} else if errors.Is(err, ErrNoSignatures) {
+		log.Info("No signatures to submit")
+	} else if errors.Is(err, ErrAlreadyVerified) {
+		// Skip if the nextIndex is already verified
+		log.Info("Already verified the rollup index")
+	} else if errors.Is(err, &StakeAmountShortage{}) {
+		// Wait until enough signatures are collected
+		var (
+			shortageErr      *StakeAmountShortage
+			required, actual *big.Int
+		)
+		if errors.As(err, &shortageErr) {
+			required, actual = fromWei(shortageErr.required), fromWei(shortageErr.actual)
+		}
+		log.Info("Not enough signatures(stake amount shortage)",
+			"nextIndex", nextIndex, "required", required, "actual", actual)
+	} else if err != nil {
+		log.Error("Failed to verify the rollup index", "err", err)
+	} else {
+		// Finally, succeeded to verify the corresponding rollup index, So move to the next index
+		task.verifiedIndex = &nextIndex
+		log.Info("Successfully verified the rollup index", "next-verified-index", *task.verifiedIndex)
+		if err := w.cleanupOldSignatures(task.verse.RollupContract(), *task.verifiedIndex); err != nil {
+			log.Warn("Failed to delete old signatures", "verified-index", *task.verifiedIndex, "err", err)
+		}
+	}
+}
+
+func (w *Submitter) cleanupOldSignatures(contract common.Address, verifiedIndex uint64) error {
 	if verifiedIndex == 0 {
 		return nil
 	}
@@ -152,117 +193,50 @@ func (w *Submitter) cleanOldSignatures(contract common.Address, verifiedIndex ui
 	return nil
 }
 
-// Deprecated:
-func (w *Submitter) workLoop(ctx context.Context) {
-	wg := util.NewWorkerGroup(w.cfg.Concurrency)
-	running := &sync.Map{}
-
-	tick := time.NewTicker(w.cfg.Interval)
-	defer tick.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			w.log.Info("Submitter stopped")
-			return
-		case <-tick.C:
-			w.tasks.Range(func(key, val any) bool {
-				workerID := key.(common.Address).Hex()
-				task := val.(verse.TransactableVerse)
-
-				// deduplication
-				if _, ok := running.Load(workerID); ok {
-					return true
-				}
-				running.Store(workerID, 1)
-
-				if !wg.Has(workerID) {
-					worker := func(ctx context.Context, rname string, data interface{}) {
-						defer running.Delete(rname)
-						w.work(ctx, data.(verse.TransactableVerse), nil)
-					}
-					wg.AddWorker(ctx, workerID, worker)
-				}
-
-				wg.Enqueue(workerID, task)
-				return true
-			})
-		}
-	}
-}
-
-func (w *Submitter) HasTask(contract common.Address) bool {
-	_, ok := w.tasks.Load(contract)
-	return ok
-}
-
-func (w *Submitter) AddTask(ctx context.Context, task verse.TransactableVerse, chainId uint64) {
-	exists := w.HasTask(task.RollupContract())
-	w.tasks.Store(task.RollupContract(), task)
-	if !exists {
-		// Start submitting loop by each contract.
-		// 1. Request signatures every interval
-		// 2. Submit verify tx if enough signatures are collected
-		go w.startSubmitter(ctx, task.RollupContract(), chainId)
-	}
-}
-
-func (w *Submitter) GetTask(contract common.Address) (task verse.TransactableVerse, found bool) {
-	var val any
-	val, found = w.tasks.Load(contract)
-	if !found {
-		return
-	}
-	task, found = val.(verse.TransactableVerse)
-	return
-}
-
 func (w *Submitter) RemoveTask(contract common.Address) {
 	w.tasks.Delete(contract)
 }
 
-func (w *Submitter) work(ctx context.Context, task verse.TransactableVerse, verifiedIndex *uint64) (uint64, error) {
-	log := task.Logger(w.log)
-
+func (w *Submitter) submit(ctx context.Context, task *taskT) (uint64, error) {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
-	// Assume the fetched nextIndex is not reorged, as we confirm `w.cfg.Confirmations` blocks
-	nextIndex, err := task.NextIndex(ctx, w.cfg.Confirmations, false)
+	nextIndex, err := w.versepool.NextIndex(ctx, task.verse.RollupContract(), w.cfg.Confirmations, false)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch next index: %w", err)
 	}
-	log = log.New("next-index", nextIndex)
+	log := task.verse.Logger(w.log).New("next-index", nextIndex)
 
-	if verifiedIndex != nil {
-		if *verifiedIndex == nextIndex {
+	if task.verifiedIndex != nil {
+		if *task.verifiedIndex == nextIndex {
 			// Skip if the nextIndex is already verified
 			return nextIndex, ErrAlreadyVerified
-		} else if *verifiedIndex > nextIndex {
+		} else if *task.verifiedIndex > nextIndex {
 			// Continue as purhaps reorged
-			log.Warn("Possible reorged. next index is smaller than the verified index", "verified-index", *verifiedIndex, "next-index", nextIndex)
+			log.Warn("Possible reorged. next index is smaller than the verified index",
+				"verified-index", *task.verifiedIndex, "next-index", nextIndex)
 		}
 	}
 
 	iter := &signatureIterator{
 		db:           w.db,
 		stakemanager: w.stakemanager,
-		contract:     task.RollupContract(),
+		contract:     task.verse.RollupContract(),
 		rollupIndex:  nextIndex,
 	}
 
 	var tx *types.Transaction
 	if w.cfg.UseMulticall {
-		tx, err = w.sendMulticallTx(log, ctx, task, iter)
+		tx, err = w.sendMulticallTx(log, ctx, task.verse, iter)
 	} else {
-		tx, err = w.sendNormalTx(log, ctx, task, iter)
+		tx, err = w.sendNormalTx(log, ctx, task.verse, iter)
 	}
 	if err != nil {
 		log.Debug(err.Error())
 		return nextIndex, fmt.Errorf("failed to send transaction: %w", err)
 	}
 
-	if err = w.waitForReceipt(ctx, task.L1Signer(), tx); err != nil {
+	if err = w.waitForReceipt(ctx, task.verse.L1Signer(), tx); err != nil {
 		return nextIndex, fmt.Errorf("failed to wait for receipt: %w", err)
 	}
 

--- a/testhelper/backend/backend.go
+++ b/testhelper/backend/backend.go
@@ -67,6 +67,10 @@ func (b *Backend) HeaderByHash(
 	return b.Client().HeaderByHash(ctx, hash)
 }
 
+func (c *Backend) HeaderWithCache(ctx context.Context) (header *types.Header, err error) {
+	return c.HeaderByNumber(ctx, nil)
+}
+
 func (b *Backend) TransactionByHash(
 	ctx context.Context,
 	txHash common.Hash,

--- a/testhelper/backend/backend.go
+++ b/testhelper/backend/backend.go
@@ -37,6 +37,10 @@ type Backend struct {
 	*simulated.Backend
 }
 
+func (c *Backend) Close() {
+	c.Backend.Close()
+}
+
 func (b *Backend) FilterLogsWithRateThottling(ctx context.Context, q ethereum.FilterQuery) (logs []types.Log, err error) {
 	return b.FilterLogs(ctx, q)
 }

--- a/testhelper/backend/suite.go
+++ b/testhelper/backend/suite.go
@@ -88,11 +88,12 @@ func (b *BackendSuite) SetupTest() {
 	b.SignableHub.Mining()
 }
 
-func (b *BackendSuite) Mining() {
+func (b *BackendSuite) Mining() *types.Header {
 	b.NotEmpty(b.SignableHub.Commit())
 	header, err := b.SignableHub.HeaderByNumber(context.Background(), nil)
 	b.NoError(err)
 	b.DB.Block.Save(header.Number.Uint64(), header.Hash())
+	return header
 }
 
 func (b *BackendSuite) EmitStateBatchAppended(index int) (

--- a/util/worker_pool.go
+++ b/util/worker_pool.go
@@ -1,0 +1,287 @@
+package util
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// WorkerPool is inspired by the worker pool implementation of fasthttp.
+// https://github.com/valyala/fasthttp
+
+// Returns a new worker pool.
+// `maxWorkersCount` is the maximum number of goroutines that can be running concurrently within the pool.
+// `maxIdleWorkerDuration(default=10s)` is the threshold for terminating idle workers.
+// If there are no idle workers in the pool when a new job is executed via the `Work` method, the pool will
+// recheck at intervals specified by `workerReleaseCheckInterval(default=0s)`. If zero is specified, the `Work` method
+// will immediately return `false`. The loop that rechecks the pool will attempt retries up to the limit
+// specified by `workerReleaseCheckTimeout(default=0s)`. If zero is specified, it will attempt retries indefinitely.
+func NewWorkerPool[T any](
+	log log.Logger,
+	handler func(*WorkerPoolJob[T]),
+	maxWorkersCount int,
+	maxIdleWorkerDuration,
+	workerReleaseCheckInterval, workerReleaseCheckTimeout time.Duration,
+) *WorkerPool[T] {
+	return &WorkerPool[T]{
+		logger:                     log,
+		workerFuncFn:               handler,
+		maxWorkersCount:            maxWorkersCount,
+		maxIdleWorkerDuration:      maxIdleWorkerDuration,
+		workerReleaseCheckInterval: workerReleaseCheckInterval,
+		workerReleaseCheckTimeout:  workerReleaseCheckTimeout,
+	}
+}
+
+type WorkerPool[T any] struct {
+	logger          log.Logger
+	workerFuncFn    func(*WorkerPoolJob[T])
+	maxWorkersCount int
+	maxIdleWorkerDuration,
+	workerReleaseCheckInterval,
+	workerReleaseCheckTimeout time.Duration
+
+	workerChanPool sync.Pool
+	stopCh         chan struct{}
+	ready          []*workerChan[T]
+	workersCount   int
+	lock           sync.Mutex
+	mustStop       bool
+}
+
+type WorkerPoolJob[T any] struct {
+	Context context.Context
+	Data    T
+}
+
+type workerChan[T any] struct {
+	lastUseTime time.Time
+	ch          chan *WorkerPoolJob[T]
+}
+
+func (wp *WorkerPool[T]) Start() {
+	if wp.stopCh != nil {
+		return
+	}
+	wp.stopCh = make(chan struct{})
+	stopCh := wp.stopCh
+	wp.workerChanPool.New = func() any {
+		return &workerChan[T]{
+			ch: make(chan *WorkerPoolJob[T], workerChanCap),
+		}
+	}
+	go func() {
+		var scratch []*workerChan[T]
+		for {
+			wp.clean(&scratch)
+			select {
+			case <-stopCh:
+				return
+			default:
+				time.Sleep(wp.getMaxIdle())
+			}
+		}
+	}()
+}
+
+func (wp *WorkerPool[T]) Stop() {
+	if wp.stopCh == nil {
+		return
+	}
+	close(wp.stopCh)
+	wp.stopCh = nil
+
+	// Stop all the workers waiting for incoming connections.
+	// Do not wait for busy workers - they will stop after
+	// serving the connection and noticing wp.mustStop = true.
+	wp.lock.Lock()
+	ready := wp.ready
+	for i := range ready {
+		ready[i].ch <- nil
+		ready[i] = nil
+	}
+	wp.ready = ready[:0]
+	wp.mustStop = true
+	wp.lock.Unlock()
+}
+
+func (wp *WorkerPool[T]) getMaxIdle() time.Duration {
+	if wp.maxIdleWorkerDuration <= 0 {
+		return 10 * time.Second
+	}
+	return wp.maxIdleWorkerDuration
+}
+
+var maxReleaseCheckLimit = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+
+func (wp *WorkerPool[T]) getWorkerReleaseTimers() (interval *time.Ticker, timeout time.Time) {
+	if wp.workerReleaseCheckInterval == 0 {
+		return
+	}
+	interval = time.NewTicker(wp.workerReleaseCheckInterval)
+
+	if wp.workerReleaseCheckTimeout == 0 {
+		timeout = maxReleaseCheckLimit
+	} else {
+		timeout = time.Now().Add(wp.workerReleaseCheckTimeout)
+	}
+	return
+}
+
+func (wp *WorkerPool[T]) clean(scratch *[]*workerChan[T]) {
+	maxIdleWorkerDuration := wp.getMaxIdle()
+
+	// Clean least recently used workers if they didn't serve connections
+	// for more than maxIdleWorkerDuration.
+	criticalTime := time.Now().Add(-maxIdleWorkerDuration)
+
+	wp.lock.Lock()
+	ready := wp.ready
+	n := len(ready)
+
+	// Use binary-search algorithm to find out the index of the least recently worker which can be cleaned up.
+	l, r := 0, n-1
+	for l <= r {
+		mid := (l + r) / 2
+		if criticalTime.After(wp.ready[mid].lastUseTime) {
+			l = mid + 1
+		} else {
+			r = mid - 1
+		}
+	}
+	i := r
+	if i == -1 {
+		wp.lock.Unlock()
+		return
+	}
+
+	*scratch = append((*scratch)[:0], ready[:i+1]...)
+	m := copy(ready, ready[i+1:])
+	for i = m; i < n; i++ {
+		ready[i] = nil
+	}
+	wp.ready = ready[:m]
+	wp.lock.Unlock()
+
+	// Notify obsolete workers to stop.
+	// This notification must be outside the wp.lock, since ch.ch
+	// may be blocking and may consume a lot of time if many workers
+	// are located on non-local CPUs.
+	tmp := *scratch
+	for i := range tmp {
+		tmp[i].ch <- nil
+		tmp[i] = nil
+	}
+}
+
+func (wp *WorkerPool[T]) Work(ctx context.Context, data T) bool {
+	waitTick, waitTimeout := wp.getWorkerReleaseTimers()
+	if waitTick != nil {
+		defer waitTick.Stop()
+	}
+
+	var ch *workerChan[T]
+	for {
+		ch = wp.getCh(ctx)
+		if ch != nil || waitTick == nil {
+			break
+		}
+
+		if time.Now().After(waitTimeout) {
+			wp.logger.Warn("Exceeded maximum wait time")
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-waitTick.C:
+		}
+	}
+
+	if ch == nil {
+		return false
+	}
+	ch.ch <- &WorkerPoolJob[T]{Context: ctx, Data: data}
+	return true
+}
+
+var workerChanCap = func() int {
+	// Use blocking workerChan if GOMAXPROCS=1.
+	// This immediately switches Serve to WorkerFunc, which results
+	// in higher performance (under go1.5 at least).
+	if runtime.GOMAXPROCS(0) == 1 {
+		return 0
+	}
+
+	// Use non-blocking workerChan if GOMAXPROCS>1,
+	// since otherwise the Serve caller (Acceptor) may lag accepting
+	// new connections if WorkerFunc is CPU-bound.
+	return 1
+}()
+
+func (wp *WorkerPool[T]) getCh(ctx context.Context) *workerChan[T] {
+	var ch *workerChan[T]
+	createWorker := false
+
+	wp.lock.Lock()
+	ready := wp.ready
+	n := len(ready) - 1
+	if n < 0 {
+		if wp.workersCount < wp.maxWorkersCount {
+			createWorker = true
+			wp.workersCount++
+		}
+	} else {
+		ch = ready[n]
+		ready[n] = nil
+		wp.ready = ready[:n]
+	}
+	wp.lock.Unlock()
+
+	if ch == nil {
+		if !createWorker {
+			return nil
+		}
+		vch := wp.workerChanPool.Get()
+		ch = vch.(*workerChan[T])
+		go func() {
+			wp.workerFunc(ch)
+			wp.workerChanPool.Put(vch)
+		}()
+	}
+	return ch
+}
+
+func (wp *WorkerPool[T]) release(ch *workerChan[T]) bool {
+	ch.lastUseTime = time.Now()
+	wp.lock.Lock()
+	if wp.mustStop {
+		wp.lock.Unlock()
+		return false
+	}
+	wp.ready = append(wp.ready, ch)
+	wp.lock.Unlock()
+	return true
+}
+
+func (wp *WorkerPool[T]) workerFunc(ch *workerChan[T]) {
+	var job *WorkerPoolJob[T]
+	for job = range ch.ch {
+		if job == nil {
+			break
+		}
+
+		wp.workerFuncFn(job)
+		if !wp.release(ch) {
+			break
+		}
+	}
+
+	wp.lock.Lock()
+	wp.workersCount--
+	wp.lock.Unlock()
+}

--- a/util/worker_pool_test.go
+++ b/util/worker_pool_test.go
@@ -1,0 +1,178 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkerPool(t *testing.T) {
+	assert := assert.New(t)
+
+	maxWorkers := 10
+	maxIdle := time.Millisecond * 10
+
+	// Not waiting for worker release
+	workerReleaseCheckInterval := time.Duration(0)
+	workerReleaseCheckTimeout := time.Duration(0)
+
+	var (
+		mu               sync.Mutex
+		calls, completed int
+	)
+	handler := func(job *WorkerPoolJob[int]) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		<-job.Context.Done()
+
+		mu.Lock()
+		completed++
+		mu.Unlock()
+	}
+
+	wp := NewWorkerPool(log.Root(), handler, maxWorkers, maxIdle,
+		workerReleaseCheckInterval, workerReleaseCheckTimeout)
+	wp.Start()
+	defer wp.Stop()
+
+	// Check if the worker pool is empty
+	assert.Equal(0, wp.workersCount)
+	assert.Equal(0, len(wp.ready))
+
+	// Run workers
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := 0; i < maxWorkers*2; i++ {
+		start := time.Now()
+		ok := wp.Work(ctx, i)
+		elapsed := time.Since(start)
+
+		if i < maxWorkers {
+			assert.True(ok)
+			assert.Equal(i+1, wp.workersCount)
+		} else {
+			assert.False(ok) // no idle workers
+			assert.Equal(maxWorkers, wp.workersCount)
+		}
+		assert.Less(elapsed, time.Microsecond*50)
+
+		assert.Equal(0, len(wp.ready))
+	}
+
+	// Wait for the worker to be executed by the worker pool
+	time.Sleep(time.Millisecond)
+	assert.Equal(maxWorkers, calls)
+
+	// Wait for completes
+	cancel()
+	time.Sleep(time.Millisecond)
+	assert.Equal(maxWorkers, completed)
+
+	// Check if the idle worker has been released
+	assert.Equal(maxWorkers, len(wp.ready))
+	time.Sleep(maxIdle * 2)
+	assert.Equal(0, len(wp.ready))
+
+	// It should be run now that it has been released.
+	assert.True(wp.Work(ctx, maxWorkers+1))
+}
+
+func TestWorkerPool_WithWaitForRelease_WithoutTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	maxWorkers := 10
+	maxIdle := time.Millisecond * 10
+
+	// Wait for worker release without timeout
+	workerReleaseCheckInterval := time.Millisecond
+	workerReleaseCheckTimeout := time.Duration(0)
+
+	var (
+		mu               sync.Mutex
+		calls, completed int
+	)
+	handler := func(job *WorkerPoolJob[int]) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		time.Sleep(workerReleaseCheckInterval)
+
+		mu.Lock()
+		completed++
+		mu.Unlock()
+	}
+
+	wp := NewWorkerPool(log.Root(), handler, maxWorkers, maxIdle,
+		workerReleaseCheckInterval, workerReleaseCheckTimeout)
+	wp.Start()
+	defer wp.Stop()
+
+	// Run workers
+	ctx := context.Background()
+	for i := 0; i < maxWorkers*2; i++ {
+		start := time.Now()
+		ok := wp.Work(ctx, i)
+		elapsed := time.Since(start)
+
+		assert.True(ok)
+		if i < maxWorkers {
+			assert.Less(elapsed, time.Microsecond*50)
+		} else {
+			assert.Less(elapsed, workerReleaseCheckInterval*2)
+		}
+	}
+}
+
+func TestWorkerPool_WithWaitForRelease_WithTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	maxWorkers := 10
+	maxIdle := time.Millisecond * 10
+
+	// Wait for worker release with timeout
+	workerReleaseCheckInterval := time.Millisecond
+	workerReleaseCheckTimeout := workerReleaseCheckInterval * 2
+
+	var (
+		mu               sync.Mutex
+		calls, completed int
+	)
+	handler := func(job *WorkerPoolJob[int]) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		time.Sleep(time.Second)
+
+		mu.Lock()
+		completed++
+		mu.Unlock()
+	}
+
+	wp := NewWorkerPool(log.Root(), handler, maxWorkers, maxIdle,
+		workerReleaseCheckInterval, workerReleaseCheckTimeout)
+	wp.Start()
+	defer wp.Stop()
+
+	// Run workers
+	ctx := context.Background()
+	for i := 0; i < maxWorkers*2; i++ {
+		start := time.Now()
+		ok := wp.Work(ctx, i)
+		elapsed := time.Since(start)
+
+		if i < maxWorkers {
+			assert.True(ok)
+			assert.Less(elapsed, time.Microsecond*50)
+		} else {
+			assert.False(ok)
+			assert.Greater(elapsed, workerReleaseCheckTimeout)
+		}
+	}
+}

--- a/util/worker_pool_test.go
+++ b/util/worker_pool_test.go
@@ -24,12 +24,12 @@ func TestWorkerPool(t *testing.T) {
 		mu               sync.Mutex
 		calls, completed int
 	)
-	handler := func(job *WorkerPoolJob[int]) {
+	handler := func(ctx context.Context, job int) {
 		mu.Lock()
 		calls++
 		mu.Unlock()
 
-		<-job.Context.Done()
+		<-ctx.Done()
 
 		mu.Lock()
 		completed++
@@ -59,7 +59,7 @@ func TestWorkerPool(t *testing.T) {
 			assert.False(ok) // no idle workers
 			assert.Equal(maxWorkers, wp.workersCount)
 		}
-		assert.Less(elapsed, time.Microsecond*50)
+		assert.Less(elapsed, time.Microsecond*100)
 
 		assert.Equal(0, len(wp.ready))
 	}
@@ -96,7 +96,7 @@ func TestWorkerPool_WithWaitForRelease_WithoutTimeout(t *testing.T) {
 		mu               sync.Mutex
 		calls, completed int
 	)
-	handler := func(job *WorkerPoolJob[int]) {
+	handler := func(ctx context.Context, job int) {
 		mu.Lock()
 		calls++
 		mu.Unlock()
@@ -122,7 +122,7 @@ func TestWorkerPool_WithWaitForRelease_WithoutTimeout(t *testing.T) {
 
 		assert.True(ok)
 		if i < maxWorkers {
-			assert.Less(elapsed, time.Microsecond*50)
+			assert.Less(elapsed, time.Microsecond*100)
 		} else {
 			assert.Less(elapsed, workerReleaseCheckInterval*2)
 		}
@@ -143,7 +143,7 @@ func TestWorkerPool_WithWaitForRelease_WithTimeout(t *testing.T) {
 		mu               sync.Mutex
 		calls, completed int
 	)
-	handler := func(job *WorkerPoolJob[int]) {
+	handler := func(ctx context.Context, job int) {
 		mu.Lock()
 		calls++
 		mu.Unlock()
@@ -169,7 +169,7 @@ func TestWorkerPool_WithWaitForRelease_WithTimeout(t *testing.T) {
 
 		if i < maxWorkers {
 			assert.True(ok)
-			assert.Less(elapsed, time.Microsecond*50)
+			assert.Less(elapsed, time.Microsecond*100)
 		} else {
 			assert.False(ok)
 			assert.Greater(elapsed, workerReleaseCheckTimeout)

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -101,8 +101,8 @@ func (w *Verifier) Start(ctx context.Context) {
 		cacheCleanupTick := time.NewTicker(time.Hour)
 		defer cacheCleanupTick.Stop()
 
-		tick := time.NewTicker(verificationInterval)
-		defer tick.Stop()
+		workTick := time.NewTicker(verificationInterval)
+		defer workTick.Stop()
 
 		w.log.Info("Verification workers started",
 			"max-workers", maxVerificationWorkers, "interval", verificationInterval)
@@ -126,7 +126,7 @@ func (w *Verifier) Start(ctx context.Context) {
 					}
 					return true
 				})
-			case <-tick.C:
+			case <-workTick.C:
 				w.versepool.Range(func(item *verse.VersePoolItem) bool {
 					log := item.Verse().Logger(w.log)
 

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -133,7 +133,6 @@ func (s *VerifierTestSuite) TestStartVerifier() {
 	}
 
 	s.Hub.Minings(10)
-	s.waitForL1HeadUpdated()
 
 	// Run a task to check that the received unverified
 	// signatures are greater than or equal to NextIndex.
@@ -177,7 +176,6 @@ func (s *VerifierTestSuite) TestStartVerifier() {
 		nextIndex++
 		s.TSCC.SetNextIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(int64(nextIndex)))
 		s.Hub.Minings(1 + s.cfg.Confirmations)
-		s.waitForL1HeadUpdated()
 
 		sigs = append(sigs, <-s.newSigP2P.sigsCh...)
 		unverifiedWait.Lock()
@@ -193,7 +191,6 @@ func (s *VerifierTestSuite) TestStartVerifier() {
 	nextIndex = rollups[len(rollups)-s.cfg.MaxIndexDiff]
 	s.TSCC.SetNextIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(int64(nextIndex)))
 	s.Hub.Minings(1 + s.cfg.Confirmations)
-	s.waitForL1HeadUpdated()
 
 	sigs = append(sigs, <-s.newSigP2P.sigsCh...)
 	unverifiedWait.Lock()
@@ -313,7 +310,6 @@ func (s *VerifierTestSuite) TestDetermineMaxEnd() {
 		}
 	}
 	latest := s.Hub.Minings(10)[9]
-	s.waitForL1HeadUpdated()
 
 	got, _ := s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
 	s.Equal(emittedBlocks[nextIndex+s.cfg.MaxIndexDiff], got)
@@ -366,14 +362,4 @@ func (s *VerifierTestSuite) sendVerseTransactions(count int) (headers []*types.H
 		headers = append(headers, h)
 	}
 	return headers
-}
-
-func (s *VerifierTestSuite) waitForL1HeadUpdated() (newPtr *types.Header) {
-	oldPtr := s.verifier.l1HeadCache.Load()
-	for {
-		time.Sleep(time.Millisecond * 10)
-		if newPtr = s.verifier.l1HeadCache.Load(); newPtr != oldPtr {
-			return
-		}
-	}
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -22,11 +22,13 @@ import (
 type VerifierTestSuite struct {
 	backend.BackendSuite
 
-	verifier *Verifier
-	cfg      *config.Verifier
-	task     verse.VerifiableVerse
+	verifier   *Verifier
+	cfg        *config.Verifier
+	verse      verse.Verse
+	verifiable verse.VerifiableVerse
 	newSigP2P,
 	unverifiedSigP2P *MockP2P
+	versepool verse.VersePool
 }
 
 func TestVerifier(t *testing.T) {
@@ -45,7 +47,15 @@ func (m *MockP2P) PublishSignatures(ctx context.Context, sigs []*database.Optimi
 func (s *VerifierTestSuite) SetupTest() {
 	s.BackendSuite.SetupTest()
 
+	// Setup verse pool
+	s.verse = verse.NewOPLegacy(s.DB, s.Hub, 12345, s.Verse.URL(), s.SCCAddr, s.SCCVAddr)
+	s.verifiable = s.verse.WithVerifiable(s.Verse)
+	s.versepool = verse.NewVersePool(s.Hub)
+	s.versepool.Add(s.verse, false)
+
+	// Setup verifier
 	s.cfg = &config.Verifier{
+		MaxWorkers:            1,
 		Interval:              time.Millisecond * 50,
 		StateCollectLimit:     3,
 		StateCollectTimeout:   time.Second,
@@ -53,9 +63,12 @@ func (s *VerifierTestSuite) SetupTest() {
 		MaxLogFetchBlockRange: 5760,
 		MaxIndexDiff:          3,
 	}
-	s.verifier = NewVerifier(s.cfg, s.DB, nil, s.SignableHub)
-	s.task = verse.NewOPLegacy(s.DB, s.Hub, s.SCCAddr).WithVerifiable(s.Verse)
+	s.verifier = NewVerifier(s.cfg, s.DB, nil, s.SignableHub, nil, s.versepool)
+	s.verifier.l2ClientFn = func(url string, blockTime time.Duration) (ethutil.Client, error) {
+		return s.Verse, nil
+	}
 
+	// Setup P2P mocks
 	s.newSigP2P = &MockP2P{sigsCh: make(chan []*database.OptimismSignature)}
 	s.unverifiedSigP2P = &MockP2P{sigsCh: make(chan []*database.OptimismSignature)}
 	s.verifier.newSigP2P = s.newSigP2P
@@ -154,7 +167,7 @@ func (s *VerifierTestSuite) TestStartVerifier() {
 	}()
 
 	// start verifier by adding task
-	s.verifier.AddTask(ctx, s.task, 0)
+	go s.verifier.Start(ctx)
 
 	// wait for verification
 	sigs := <-s.newSigP2P.sigsCh
@@ -311,29 +324,29 @@ func (s *VerifierTestSuite) TestDetermineMaxEnd() {
 	}
 	latest := s.Hub.Minings(10)[9]
 
-	got, _ := s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
+	got, _ := s.verifier.determineMaxEnd(ctx, s.verifiable, uint64(nextIndex))
 	s.Equal(emittedBlocks[nextIndex+s.cfg.MaxIndexDiff], got)
 
 	// Increase NextIndex to 1.
 	nextIndex = 1
-	got, _ = s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
+	got, _ = s.verifier.determineMaxEnd(ctx, s.verifiable, uint64(nextIndex))
 	s.Equal(emittedBlocks[nextIndex+s.cfg.MaxIndexDiff], got)
 
 	// Increase NextIndex to 3.
 	nextIndex = 3
-	got, _ = s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
+	got, _ = s.verifier.determineMaxEnd(ctx, s.verifiable, uint64(nextIndex))
 	s.Equal(emittedBlocks[nextIndex+s.cfg.MaxIndexDiff], got)
 
 	// Increase NextIndex to 6.
 	// The Key point is that `6+MaxIndexDiff`` has not yet exceeded the maximum index.
 	nextIndex = 6
-	got, _ = s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
+	got, _ = s.verifier.determineMaxEnd(ctx, s.verifiable, uint64(nextIndex))
 	s.Equal(emittedBlocks[nextIndex+s.cfg.MaxIndexDiff], got)
 
 	// Increase NextIndex to 7.
 	// Since `7+MaxIndexDiff` exceeds the maximum index, `L1Head-Confirmations` should be returned.
 	nextIndex = 7
-	got, _ = s.verifier.determineMaxEnd(ctx, s.task, uint64(nextIndex))
+	got, _ = s.verifier.determineMaxEnd(ctx, s.verifiable, uint64(nextIndex))
 	s.Equal(latest.Number.Uint64()-uint64(s.cfg.Confirmations), got)
 }
 

--- a/verse/opstack_test.go
+++ b/verse/opstack_test.go
@@ -30,7 +30,7 @@ func TestOPStack(t *testing.T) {
 func (s *OPStackTestSuite) SetupTest() {
 	s.BackendSuite.SetupTest()
 
-	s.verse = NewOPStack(s.DB, s.Hub, s.L2OOAddr)
+	s.verse = NewOPStack(s.DB, s.Hub, 12345, s.Hub.URL(), s.L2OOAddr, s.L2OOVAddr)
 	s.verifiable = s.verse.WithVerifiable(s.Verse)
 	s.transactable = s.verse.WithTransactable(s.SignableHub, s.L2OOVAddr)
 }
@@ -44,24 +44,21 @@ func (s *OPStackTestSuite) TestEventDB() {
 
 func (s *OPStackTestSuite) TestNextIndex() {
 	ctx := context.Background()
-	confirmation := 0
-	waits := false
 
 	s.TL2OO.SetNextVerifyIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(10))
-	s.Mining()
+	header := s.Mining()
 
-	got0, _ := s.verse.NextIndex(ctx, confirmation, waits)
-	got1, _ := s.verifiable.NextIndex(ctx, confirmation, waits)
-	got2, _ := s.transactable.NextIndex(ctx, confirmation, waits)
+	opts := &bind.CallOpts{Context: ctx, BlockNumber: header.Number}
+	got0, _ := s.verse.NextIndex(opts)
+	got1, _ := s.verifiable.NextIndex(opts)
+	got2, _ := s.transactable.NextIndex(opts)
 	s.Equal(uint64(10), got0)
 	s.Equal(uint64(10), got1)
 	s.Equal(uint64(10), got2)
 }
 
-func (s *OPStackTestSuite) TestGetEventEmittedBlock() {
+func (s *OPStackTestSuite) TestEventEmittedBlock() {
 	ctx := context.Background()
-	confirmation := 0
-	waits := false
 	nextIndex := uint64(10)
 
 	s.EmitOutputProposed(int(nextIndex) - 1)
@@ -73,9 +70,10 @@ func (s *OPStackTestSuite) TestGetEventEmittedBlock() {
 
 	expect, _ := s.Hub.TransactionReceipt(ctx, tx.Hash())
 
-	got0, _ := s.verse.GetEventEmittedBlock(ctx, nextIndex, confirmation, waits)
-	got1, _ := s.verifiable.GetEventEmittedBlock(ctx, nextIndex, confirmation, waits)
-	got2, _ := s.transactable.GetEventEmittedBlock(ctx, nextIndex, confirmation, waits)
+	opts := &bind.FilterOpts{Context: ctx}
+	got0, _ := s.verse.EventEmittedBlock(opts, nextIndex)
+	got1, _ := s.verifiable.EventEmittedBlock(opts, nextIndex)
+	got2, _ := s.transactable.EventEmittedBlock(opts, nextIndex)
 
 	s.Equal(expect.BlockNumber.Uint64(), got0)
 	s.Equal(expect.BlockNumber.Uint64(), got1)

--- a/verse/verse.go
+++ b/verse/verse.go
@@ -155,17 +155,15 @@ func decideConfirmationBlockNumber(ctx context.Context, confirmation int, client
 	}
 	confirmationU64 := uint64(confirmation)
 
-	var (
-		latest uint64
-		err    error
-	)
 	// The block heights of the Mainnet/Testnet have grown sufficiently,
 	// so this loop is intended for the local chain.
+	var latest uint64
 	for {
-		latest, err = client.BlockNumber(ctx)
+		header, err := client.HeaderWithCache(ctx)
 		if err != nil {
 			return 0, fmt.Errorf("failed to fetch latest block height: %w", err)
 		}
+		latest = header.Number.Uint64()
 		if latest >= confirmationU64 {
 			break
 		}

--- a/verse/verse_pool.go
+++ b/verse/verse_pool.go
@@ -167,7 +167,7 @@ func (pool *versePool) NextIndex(
 			fsbCache = nil
 		}
 	}
-	if fsbCache == nil {
+	if fsbCache == nil && ni > 0 {
 		// Get one previous event since the event matching the next index may not have been emitted yet.
 		previ := ni - 1
 		emitted, err := pool.EventEmittedBlock(ctx, contract, previ, confirmation, true)

--- a/verse/verse_pool.go
+++ b/verse/verse_pool.go
@@ -1,0 +1,184 @@
+package verse
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/oasysgames/oasys-optimism-verifier/ethutil"
+	"github.com/oasysgames/oasys-optimism-verifier/util"
+)
+
+const (
+	// Since the current usage doesn't result in a high
+	// cache hit rate, the cache size will be kept modest.
+	emittedBlockCacheSize = 16
+)
+
+var (
+	_ VersePool = &versePool{}
+)
+
+// VersePool is a pool of `Verse` instances that can be shared across the entire application.
+// All methods are goroutine safe.
+type VersePool interface {
+	// Add a new Verse to the pool.
+	Add(new Verse, canSubmit bool) bool
+
+	// Get Verse from the pool.
+	Get(contract common.Address) (*VersePoolItem, bool)
+
+	// Removes the Verse from the pool. Does nothing if it does not exist.
+	Delete(contract common.Address)
+
+	// Get Verse from the pool one by one and pass it to the callback function.
+	Range(func(item *VersePoolItem) bool)
+
+	// Returns the next rollup index to be verified. Since the values are cached within
+	// the pool, the cache will be returned if the L1 block has not changed since the last access.
+	// If `confirmation` is greater than 1, call the method with the block number specified as
+	// `latest - confirmation`. If the latest block is smaller than `confirmation` and `waits`
+	// is true, it will wait for the number of confirmations to pass.
+	// (Since the mainnet/testnet has grown sufficiently, there won't be any waiting.)
+	NextIndex(
+		ctx context.Context,
+		contract common.Address,
+		confirmation int,
+		waits bool,
+	) (uint64, error)
+
+	// Returns the block number at which the event with the given rollup index was emitted on the L1.
+	// Since the values are cached within the pool, the cache will be returned if the L1 block has
+	// not changed since the last retrieval. If the confirmation is greater than 1, call the method
+	// with the block number of 'latest - confirmation'. If the latest block is smaller than
+	// `confirmation` and `waits` is true, it will wait for the number of confirmations to pass.
+	// (Since the mainnet/testnet has grown sufficiently, there won't be any waiting.)
+	EventEmittedBlock(
+		ctx context.Context,
+		contract common.Address,
+		rollupIndex uint64,
+		confirmation int,
+		waits bool,
+	) (uint64, error)
+}
+
+type VersePoolItem struct {
+	verse             Verse
+	canSubmit         bool
+	nextIndexCache    atomic.Pointer[nextIndexCache]
+	emittedBlockCache *lru.Cache[uint64, uint64]
+}
+
+type nextIndexCache struct {
+	fetchedBlock,
+	value uint64
+}
+
+func NewVersePool(l1Client ethutil.Client) VersePool {
+	return &versePool{l1Client: l1Client}
+}
+
+type versePool struct {
+	l1Client ethutil.Client
+	verses   util.SyncMap[common.Address, *VersePoolItem]
+}
+
+func (pool *versePool) Add(new Verse, canSubmit bool) bool {
+	cacheKey := new.RollupContract()
+
+	old, _ := pool.verses.Load(cacheKey)
+	if old != nil && old.Verse().URL() == new.URL() && old.canSubmit == canSubmit {
+		return false
+	}
+
+	blkCache, _ := lru.New[uint64, uint64](emittedBlockCacheSize)
+	pool.verses.Store(cacheKey, &VersePoolItem{
+		verse:             new,
+		canSubmit:         canSubmit,
+		emittedBlockCache: blkCache,
+	})
+	return true
+}
+
+func (pool *versePool) Get(contract common.Address) (*VersePoolItem, bool) {
+	return pool.verses.Load(contract)
+}
+
+func (pool *versePool) Delete(contract common.Address) {
+	pool.verses.Delete(contract)
+}
+
+func (pool *versePool) Range(fn func(*VersePoolItem) bool) {
+	pool.verses.Range(func(key common.Address, value *VersePoolItem) bool {
+		return fn(value)
+	})
+}
+
+func (pool *versePool) NextIndex(
+	ctx context.Context,
+	contract common.Address,
+	confirmation int,
+	waits bool,
+) (uint64, error) {
+	item, ok := pool.verses.Load(contract)
+	if !ok {
+		return 0, fmt.Errorf("not in the pool: %s", contract)
+	}
+
+	// Assume the fetched nextIndex is not reorged, as we confirm `confirmation` blocks
+	confirmed, err := decideConfirmationBlockNumber(ctx, confirmation, pool.l1Client, waits)
+	if err != nil {
+		return 0, err
+	}
+
+	cache := item.nextIndexCache.Load()
+	if cache != nil && cache.fetchedBlock >= confirmed {
+		return cache.value, nil
+	}
+
+	opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(confirmed)}
+	ni, err := item.verse.NextIndex(opts)
+	if err != nil {
+		return 0, err
+	}
+
+	item.nextIndexCache.Store(&nextIndexCache{fetchedBlock: confirmed, value: ni})
+	return ni, nil
+}
+
+func (pool *versePool) EventEmittedBlock(
+	ctx context.Context,
+	contract common.Address,
+	rollupIndex uint64,
+	confirmation int,
+	waits bool,
+) (uint64, error) {
+	item, ok := pool.verses.Load(contract)
+	if !ok {
+		return 0, fmt.Errorf("not in the pool: %s", contract)
+	}
+	if cache, ok := item.emittedBlockCache.Get(rollupIndex); ok {
+		return cache, nil
+	}
+
+	confirmed, err := decideConfirmationBlockNumber(ctx, confirmation, pool.l1Client, waits)
+	if err != nil {
+		return 0, err
+	}
+
+	opts := &bind.FilterOpts{Context: ctx, End: &confirmed}
+	emittedBlock, err := item.verse.EventEmittedBlock(opts, rollupIndex)
+	if err != nil {
+		return 0, err
+	}
+
+	item.emittedBlockCache.Add(rollupIndex, emittedBlock)
+	return emittedBlock, nil
+}
+
+func (item *VersePoolItem) Verse() Verse    { return item.verse }
+func (item *VersePoolItem) CanSubmit() bool { return item.canSubmit }

--- a/verse/verse_pool_test.go
+++ b/verse/verse_pool_test.go
@@ -1,0 +1,173 @@
+package verse
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/oasysgames/oasys-optimism-verifier/testhelper/backend"
+	"github.com/stretchr/testify/suite"
+)
+
+type VersePoolTestSuite struct {
+	backend.BackendSuite
+
+	pool VersePool
+	verse1,
+	verse2 Verse
+}
+
+func TestVersePool(t *testing.T) {
+	suite.Run(t, new(VersePoolTestSuite))
+}
+
+func (s *VersePoolTestSuite) SetupTest() {
+	s.BackendSuite.SetupTest()
+
+	s.pool = NewVersePool(s.Hub)
+	s.verse1 = NewOPLegacy(s.DB, s.Hub, 1, s.Hub.URL(), s.SCCAddr, s.SCCVAddr)
+	s.verse2 = NewOPStack(s.DB, s.Hub, 2, s.Hub.URL(), s.L2OOAddr, s.L2OOVAddr)
+}
+
+func (s *VersePoolTestSuite) TestAdd_Get_Range() {
+	// Get verse1
+	got0, got1 := s.pool.Get(s.verse1.RollupContract())
+	s.Nil(got0)
+	s.False(got1)
+
+	// Add verse1
+	s.pool.Add(s.verse1, false)
+	got0, _ = s.pool.Get(s.verse1.RollupContract())
+	s.Equal(s.verse1, got0.Verse())
+	s.False(got0.CanSubmit())
+
+	// Range verse1
+	rangeItems := make(map[uint64]*VersePoolItem)
+	s.pool.Range(func(item *VersePoolItem) bool {
+		rangeItems[item.Verse().ChainID()] = item
+		return true
+	})
+	s.Len(rangeItems, 1)
+	s.Equal(s.verse1, rangeItems[s.verse1.ChainID()].Verse())
+	s.False(rangeItems[s.verse1.ChainID()].CanSubmit())
+
+	// Get verse2
+	got0, got1 = s.pool.Get(s.verse2.RollupContract())
+	s.Nil(got0)
+	s.False(got1)
+
+	// Add verse1
+	s.pool.Add(s.verse2, true)
+	got0, _ = s.pool.Get(s.verse2.RollupContract())
+	s.Equal(s.verse2, got0.Verse())
+	s.True(got0.CanSubmit())
+
+	// Range verse2
+	rangeItems = make(map[uint64]*VersePoolItem)
+	s.pool.Range(func(item *VersePoolItem) bool {
+		rangeItems[item.Verse().ChainID()] = item
+		return true
+	})
+	s.Len(rangeItems, 2)
+	s.Equal(s.verse1, rangeItems[s.verse1.ChainID()].Verse())
+	s.False(rangeItems[s.verse1.ChainID()].CanSubmit())
+	s.Equal(s.verse2, rangeItems[s.verse2.ChainID()].Verse())
+	s.True(rangeItems[s.verse2.ChainID()].CanSubmit())
+
+}
+
+func (s *VersePoolTestSuite) TestDelete() {
+	s.pool.Add(s.verse1, false)
+	s.pool.Delete(s.verse1.RollupContract())
+	got0, got1 := s.pool.Get(s.verse1.RollupContract())
+	s.Nil(got0)
+	s.False(got1)
+}
+
+func (s *VersePoolTestSuite) TestNextIndex() {
+	confirmation := 3
+	ctx := context.Background()
+
+	// If it does not exist in the pool, an error should be returned
+	_, err := s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+	s.ErrorContains(err, "not in the pool")
+
+	// Add pool
+	s.pool.Add(s.verse1, false)
+
+	// 1st call
+	got, _ := s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+	s.Equal(uint64(0), got)
+
+	// Update next index
+	s.TSCC.SetNextIndex(s.SignableHub.TransactOpts(ctx), big.NewInt(1))
+
+	// Since the block is not yet confirmed, the cache should be returned.
+	for range s.Range(0, confirmation) {
+		s.Hub.Mining()
+		got, _ = s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+		s.Equal(uint64(0), got)
+	}
+
+	// Since the block has been confirmed, a new value should be returned.
+	s.Hub.Mining()
+	got, _ = s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+	s.Equal(uint64(1), got)
+
+	// And the cache should also be updated.
+	got, _ = s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+	s.Equal(uint64(1), got)
+
+	// Adjust latest block.
+	s.Hub.Minings(10)
+}
+
+func (s *VersePoolTestSuite) TestEventEmittedBlock() {
+	confirmation := 3
+	ctx := context.Background()
+
+	// If it does not exist in the pool, an error should be returned
+	_, err := s.pool.NextIndex(ctx, s.verse1.RollupContract(), confirmation, true)
+	s.ErrorContains(err, "not in the pool")
+
+	// Add pool
+	s.pool.Add(s.verse1, false)
+
+	// Emit rollup event
+	rollupIndex := 0
+	s.EmitStateBatchAppended(rollupIndex)
+	want0, _ := s.Hub.BlockNumber(ctx)
+
+	// Since the block is not yet confirmed, the `ErrEventNotFound` should be returned.
+	for range s.Range(0, confirmation-1) {
+		s.Hub.Mining()
+		_, err = s.pool.EventEmittedBlock(
+			ctx, s.verse1.RollupContract(), uint64(rollupIndex), confirmation, true)
+		s.ErrorIs(err, ErrEventNotFound)
+	}
+
+	// Since the block has been confirmed, emitted block should be returned.
+	s.Hub.Mining()
+	got0, _ := s.pool.EventEmittedBlock(
+		ctx, s.verse1.RollupContract(), uint64(rollupIndex), confirmation, true)
+	s.Equal(want0, got0)
+
+	// Emit rollup event
+	rollupIndex++
+	s.EmitStateBatchAppended(1)
+	want1, _ := s.Hub.BlockNumber(ctx)
+
+	// Since the block is not yet confirmed, the cache should be returned.
+	for range s.Range(0, confirmation-1) {
+		s.Hub.Mining()
+		_, err = s.pool.EventEmittedBlock(
+			ctx, s.verse1.RollupContract(), uint64(rollupIndex), confirmation, true)
+		s.ErrorIs(err, ErrEventNotFound)
+	}
+
+	// Since the block has been confirmed, emitted block should be returned.
+	s.Hub.Mining()
+	got1, _ := s.pool.EventEmittedBlock(
+		ctx, s.verse1.RollupContract(), uint64(rollupIndex), confirmation, true)
+	s.Equal(want1, got1)
+}

--- a/verse/verse_test.go
+++ b/verse/verse_test.go
@@ -43,7 +43,7 @@ func (s *VerseTestSuite) SetupTest() {
 
 	factory := newVerseFactory(func(v Verse) Verse { return v })
 
-	s.verse = factory(s.db, s.l1Client, s.rollupContract)
+	s.verse = factory(s.db, s.l1Client, 12345, s.l1Client.URL(), s.rollupContract, s.verifyContract)
 	s.verifiable = s.verse.WithVerifiable(s.l2Client)
 	s.transactable = s.verifiable.WithTransactable(s.l1Signer, s.verifyContract)
 }


### PR DESCRIPTION
- fasthttpを参考にworker poolを導入
- アプリケーション全体で共有可能なverse poolを導入
  - これに伴いdiscovery jsonから削除されたverseを処理対象から除外できるようになった
- L1最新ブロックをキャッシュするために`Client.HeaderWithCache(...)`メソッドを追加
- その他可能な限りインスタンス・キャッシュを導入